### PR TITLE
Replace dashboard navigation links with buttons, redirect form POSTs to dashboard

### DIFF
--- a/fermenter/src/web/handlers.rs
+++ b/fermenter/src/web/handlers.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::Ordering;
 
 use axum::extract::State;
-use axum::response::Html;
+use axum::response::{Html, IntoResponse, Redirect, Response};
 use axum::{Form, Json};
 use chrono::Local;
 use serde::{Deserialize, Serialize};
@@ -47,12 +47,11 @@ pub(crate) async fn status(State(state): State<AppState>) -> Result<Html<String>
 }
 
 /// Context for `target_form.html`, shared by the `GET` (display) and `POST`
-/// (re-render on validation failure, or confirm on success) handlers.
+/// (re-render on validation failure) handlers.
 #[derive(Serialize)]
 pub(crate) struct TargetFormContext {
     target: f64,
     error: Option<String>,
-    confirmed: bool,
 }
 
 /// `GET /target` — target-setpoint form pre-filled with the current target
@@ -65,7 +64,6 @@ pub(crate) async fn target_form(State(state): State<AppState>) -> Result<Html<St
         TargetFormContext {
             target: current,
             error: None,
-            confirmed: false,
         },
     )
 }
@@ -87,7 +85,7 @@ pub(crate) struct TargetForm {
 pub(crate) async fn set_target(
     State(state): State<AppState>,
     Form(form): Form<TargetForm>,
-) -> Result<Html<String>> {
+) -> Result<Response> {
     match validate_target(&form.target) {
         Ok(value) => {
             let previous = *state.target_tx.borrow();
@@ -99,15 +97,7 @@ pub(crate) async fn set_target(
             if let Err(e) = persist_target(state.store.as_ref(), value, &current_brew_id).await {
                 warn!(error = %e, "failed to persist target temperature — continuing");
             }
-            render(
-                &state.env,
-                "target_form.html",
-                TargetFormContext {
-                    target: value,
-                    error: None,
-                    confirmed: true,
-                },
-            )
+            Ok(Redirect::to("/").into_response())
         }
         Err(message) => {
             let current = *state.target_tx.borrow();
@@ -117,20 +107,19 @@ pub(crate) async fn set_target(
                 TargetFormContext {
                     target: current,
                     error: Some(message),
-                    confirmed: false,
                 },
             )
+            .map(|h| h.into_response())
         }
     }
 }
 
 /// Context for `brew_form.html`, shared by the `GET` (display) and `POST`
-/// (re-render on validation failure, or confirm on success) handlers.
+/// (re-render on validation failure) handlers.
 #[derive(Serialize)]
 pub(crate) struct BrewFormContext {
     brew_id: String,
     error: Option<String>,
-    confirmed: bool,
 }
 
 /// `GET /brew` — brew-identifier form pre-filled with the current brew
@@ -144,7 +133,6 @@ pub(crate) async fn brew_form(State(state): State<AppState>) -> Result<Html<Stri
         BrewFormContext {
             brew_id: current,
             error: None,
-            confirmed: false,
         },
     )
 }
@@ -171,7 +159,7 @@ pub(crate) struct BrewForm {
 pub(crate) async fn set_brew(
     State(state): State<AppState>,
     Form(form): Form<BrewForm>,
-) -> Result<Html<String>> {
+) -> Result<Response> {
     match validate_brew_id(&form.brew_id) {
         Ok(value) => {
             let previous = state.brew_tx.borrow().clone();
@@ -188,15 +176,7 @@ pub(crate) async fn set_brew(
             let rehydrated = ingest::rehydrate_latest_reading(state.store.as_ref(), &value).await;
             *state.latest.lock().unwrap() = rehydrated;
 
-            render(
-                &state.env,
-                "brew_form.html",
-                BrewFormContext {
-                    brew_id: value,
-                    error: None,
-                    confirmed: true,
-                },
-            )
+            Ok(Redirect::to("/").into_response())
         }
         Err(message) => {
             let current = state.brew_tx.borrow().clone();
@@ -206,9 +186,9 @@ pub(crate) async fn set_brew(
                 BrewFormContext {
                     brew_id: current,
                     error: Some(message),
-                    confirmed: false,
                 },
             )
+            .map(|h| h.into_response())
         }
     }
 }
@@ -272,6 +252,18 @@ mod tests {
     }
 
     #[test]
+    fn dashboard_renders_snapshot() {
+        let env = build_environment();
+        let ctx = StatusContext {
+            reading: Some(sample_reading()),
+            brew_id: "00-TEST-v00".to_string(),
+            server_time: "14-Jul-2026 14:30:45".to_string(),
+        };
+        let html = render(&env, "dashboard.html", ctx).unwrap();
+        insta::assert_snapshot!(html.0);
+    }
+
+    #[test]
     fn status_fragment_includes_reason_code() {
         let env = build_environment();
         let ctx = StatusContext {
@@ -290,7 +282,6 @@ mod tests {
         let ctx = TargetFormContext {
             target: 19.5,
             error: None,
-            confirmed: false,
         };
         let html = render(&env, "target_form.html", ctx).unwrap();
         insta::assert_snapshot!(html.0);
@@ -302,7 +293,6 @@ mod tests {
         let ctx = TargetFormContext {
             target: 19.5,
             error: Some("'abc' is not a valid number".to_string()),
-            confirmed: false,
         };
         let html = render(&env, "target_form.html", ctx).unwrap();
         insta::assert_snapshot!(html.0);
@@ -314,10 +304,68 @@ mod tests {
         let ctx = BrewFormContext {
             brew_id: "00-TEST-v00".to_string(),
             error: None,
-            confirmed: false,
         };
         let html = render(&env, "brew_form.html", ctx).unwrap();
         insta::assert_snapshot!(html.0);
+    }
+
+    #[test]
+    fn dashboard_uses_buttons_not_links_for_navigation() {
+        let env = build_environment();
+        let ctx = StatusContext {
+            reading: Some(sample_reading()),
+            brew_id: "00-TEST-v00".to_string(),
+            server_time: "14-Jul-2026 14:30:45".to_string(),
+        };
+        let html = render(&env, "dashboard.html", ctx).unwrap();
+        assert!(html.0.contains("<button"), "dashboard must use buttons");
+        assert!(
+            !html.0.contains("<a href=\"/target\">"),
+            "dashboard must not use <a> link for target navigation"
+        );
+        assert!(
+            !html.0.contains("<a href=\"/brew\">"),
+            "dashboard must not use <a> link for brew navigation"
+        );
+    }
+
+    #[test]
+    fn form_templates_do_not_contain_back_link_or_confirmed_block() {
+        let env = build_environment();
+        let html = render(
+            &env,
+            "target_form.html",
+            TargetFormContext {
+                target: 19.5,
+                error: None,
+            },
+        )
+        .unwrap();
+        assert!(
+            !html.0.contains("Back to dashboard"),
+            "target form must not contain back link"
+        );
+        assert!(
+            !html.0.contains(r#"class="confirmed""#),
+            "target form must not contain confirmed block"
+        );
+        let html = render(
+            &env,
+            "brew_form.html",
+            BrewFormContext {
+                brew_id: "00-TEST-v00".to_string(),
+                error: None,
+            },
+        )
+        .unwrap();
+        assert!(
+            !html.0.contains("Back to dashboard"),
+            "brew form must not contain back link"
+        );
+        assert!(
+            !html.0.contains(r#"class="confirmed""#),
+            "brew form must not contain confirmed block"
+        );
     }
 
     #[test]
@@ -326,7 +374,6 @@ mod tests {
         let ctx = BrewFormContext {
             brew_id: "00-TEST-v00".to_string(),
             error: Some("brew identifier must not be empty".to_string()),
-            confirmed: false,
         };
         let html = render(&env, "brew_form.html", ctx).unwrap();
         insta::assert_snapshot!(html.0);

--- a/fermenter/src/web/mod.rs
+++ b/fermenter/src/web/mod.rs
@@ -366,7 +366,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn valid_post_target_updates_state_and_confirms() {
+    async fn valid_post_target_updates_state_and_redirects() {
         let state = test_state_with_target(None, 19.5);
         let target_rx = state.target_tx.subscribe();
         let router = build_router(state);
@@ -376,9 +376,16 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = body_string(response).await;
-        assert!(body.contains("21"));
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
+        assert_eq!(
+            response
+                .headers()
+                .get("location")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "/"
+        );
         assert_eq!(*target_rx.borrow(), 21.0);
     }
 
@@ -428,7 +435,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
     }
 
     #[tokio::test]
@@ -446,7 +453,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn valid_post_brew_updates_state_and_confirms() {
+    async fn valid_post_brew_updates_state_and_redirects() {
         let state = test_state_with_brew(None, "00-TEST-v00");
         let brew_rx = state.brew_tx.subscribe();
         let router = build_router(state);
@@ -456,9 +463,16 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = body_string(response).await;
-        assert!(body.contains("01-IPA-v02"));
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
+        assert_eq!(
+            response
+                .headers()
+                .get("location")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "/"
+        );
         assert_eq!(*brew_rx.borrow(), "01-IPA-v02");
     }
 

--- a/fermenter/src/web/snapshots/fermenter__web__handlers__tests__brew_form_with_current_brew_snapshot.snap
+++ b/fermenter/src/web/snapshots/fermenter__web__handlers__tests__brew_form_with_current_brew_snapshot.snap
@@ -1,5 +1,6 @@
 ---
 source: src/web/handlers.rs
+assertion_line: 332
 expression: html.0
 ---
 <!DOCTYPE html>
@@ -21,15 +22,11 @@ expression: html.0
 
 
 
-
-
 <form method="post" action="/brew">
     <label for="brew_id">Brew identifier</label>
     <input type="text" id="brew_id" name="brew_id" value="00-TEST-v00">
     <button type="submit">Update</button>
 </form>
-
-<p><a href="/">Back to dashboard</a></p>
 
     </main>
 </body>

--- a/fermenter/src/web/snapshots/fermenter__web__handlers__tests__brew_form_with_error_snapshot.snap
+++ b/fermenter/src/web/snapshots/fermenter__web__handlers__tests__brew_form_with_error_snapshot.snap
@@ -1,5 +1,6 @@
 ---
 source: src/web/handlers.rs
+assertion_line: 344
 expression: html.0
 ---
 <!DOCTYPE html>
@@ -23,15 +24,11 @@ expression: html.0
 <p class="error">brew identifier must not be empty</p>
 
 
-
-
 <form method="post" action="/brew">
     <label for="brew_id">Brew identifier</label>
     <input type="text" id="brew_id" name="brew_id" value="00-TEST-v00">
     <button type="submit">Update</button>
 </form>
-
-<p><a href="/">Back to dashboard</a></p>
 
     </main>
 </body>

--- a/fermenter/src/web/snapshots/fermenter__web__handlers__tests__dashboard_renders_snapshot.snap
+++ b/fermenter/src/web/snapshots/fermenter__web__handlers__tests__dashboard_renders_snapshot.snap
@@ -1,0 +1,42 @@
+---
+source: src/web/handlers.rs
+expression: html.0
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Fermenter — Dashboard</title>
+    <link rel="stylesheet" href="/static/styles.css">
+    <script src="https://unpkg.com/htmx.org@2"></script>
+</head>
+<body>
+    <header>
+        <h1>Fermenter</h1>
+    </header>
+    <main>
+        
+<div hx-get="/status" hx-trigger="every 5s" hx-swap="innerHTML">
+    <div id="status" class="status">
+    <p class="brew-id">Brew: <strong>00-TEST-v00</strong></p>
+    <p class="server-time">Server time: 14-Jul-2026 14:30:45</p>
+    
+    <dl class="reading">
+        <dt>Action</dt><dd>heating</dd>
+        <dt>Reason</dt><dd>below-target</dd>
+        <dt>Target</dt><dd>19.5&deg;</dd>
+        <dt>Average</dt><dd>18.7&deg;</dd>
+        <dt>Min</dt><dd>18.0&deg;</dd>
+        <dt>Max</dt><dd>19.0&deg;</dd>
+        <dt>Ambient</dt><dd>20.1&deg;</dd>
+    </dl>
+    
+</div>
+</div>
+<form method="get" action="/target"><button type="submit">Set target temperature</button></form>
+<form method="get" action="/brew"><button type="submit">Change brew identifier</button></form>
+
+    </main>
+</body>
+</html>

--- a/fermenter/src/web/snapshots/fermenter__web__handlers__tests__target_form_with_current_target_snapshot.snap
+++ b/fermenter/src/web/snapshots/fermenter__web__handlers__tests__target_form_with_current_target_snapshot.snap
@@ -1,5 +1,6 @@
 ---
 source: src/web/handlers.rs
+assertion_line: 308
 expression: html.0
 ---
 <!DOCTYPE html>
@@ -21,15 +22,11 @@ expression: html.0
 
 
 
-
-
 <form method="post" action="/target">
     <label for="target">Target temperature (&deg;C)</label>
     <input type="text" id="target" name="target" value="19.5">
     <button type="submit">Update</button>
 </form>
-
-<p><a href="/">Back to dashboard</a></p>
 
     </main>
 </body>

--- a/fermenter/src/web/snapshots/fermenter__web__handlers__tests__target_form_with_error_snapshot.snap
+++ b/fermenter/src/web/snapshots/fermenter__web__handlers__tests__target_form_with_error_snapshot.snap
@@ -1,5 +1,6 @@
 ---
 source: src/web/handlers.rs
+assertion_line: 320
 expression: html.0
 ---
 <!DOCTYPE html>
@@ -23,15 +24,11 @@ expression: html.0
 <p class="error">&#x27;abc&#x27; is not a valid number</p>
 
 
-
-
 <form method="post" action="/target">
     <label for="target">Target temperature (&deg;C)</label>
     <input type="text" id="target" name="target" value="19.5">
     <button type="submit">Update</button>
 </form>
-
-<p><a href="/">Back to dashboard</a></p>
 
     </main>
 </body>

--- a/fermenter/templates/brew_form.html
+++ b/fermenter/templates/brew_form.html
@@ -9,15 +9,9 @@
 <p class="error">{{ error }}</p>
 {% endif %}
 
-{% if confirmed %}
-<p class="confirmed">Brew identifier updated to {{ brew_id }}.</p>
-{% endif %}
-
 <form method="post" action="/brew">
     <label for="brew_id">Brew identifier</label>
     <input type="text" id="brew_id" name="brew_id" value="{{ brew_id }}">
     <button type="submit">Update</button>
 </form>
-
-<p><a href="/">Back to dashboard</a></p>
 {% endblock %}

--- a/fermenter/templates/dashboard.html
+++ b/fermenter/templates/dashboard.html
@@ -6,6 +6,6 @@
 <div hx-get="/status" hx-trigger="every 5s" hx-swap="innerHTML">
     {% include "partials/status.html" %}
 </div>
-<p><a href="/target">Set target temperature</a></p>
-<p><a href="/brew">Change brew identifier</a></p>
+<form method="get" action="/target"><button type="submit">Set target temperature</button></form>
+<form method="get" action="/brew"><button type="submit">Change brew identifier</button></form>
 {% endblock %}

--- a/fermenter/templates/target_form.html
+++ b/fermenter/templates/target_form.html
@@ -9,15 +9,9 @@
 <p class="error">{{ error }}</p>
 {% endif %}
 
-{% if confirmed %}
-<p class="confirmed">Target temperature updated to {{ target }}&deg;.</p>
-{% endif %}
-
 <form method="post" action="/target">
     <label for="target">Target temperature (&deg;C)</label>
     <input type="text" id="target" name="target" value="{{ target }}">
     <button type="submit">Update</button>
 </form>
-
-<p><a href="/">Back to dashboard</a></p>
 {% endblock %}

--- a/openspec/changes/ui-links-to-buttons/.openspec.yaml
+++ b/openspec/changes/ui-links-to-buttons/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/openspec/changes/ui-links-to-buttons/design.md
+++ b/openspec/changes/ui-links-to-buttons/design.md
@@ -1,0 +1,47 @@
+## Context
+
+The dashboard currently uses bare `<a href>` links for navigation to the two mutating forms (`/target` and `/brew`). Both forms, after a successful POST, re-render the same page with a confirmation message and a "Back to dashboard" link at the bottom. Invalid submissions also re-render the same page, with an error message — this behavior is correct and must be preserved.
+
+The template engine is MiniJinja (server-side), and the pages extend `base.html`. There is no custom client-side JavaScript; HTMX is available for future use but is not needed for this change.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Replace dashboard navigation links with `<button>` elements inside `<form method="get">` wrappers for pure-HTML navigation
+- On successful `POST /target`, respond with an HTTP 303 redirect to `/` instead of re-rendering the form
+- On successful `POST /brew`, respond with an HTTP 303 redirect to `/` instead of re-rendering the form
+- Remove the "Back to dashboard" link from both form templates
+- Remove the confirmation message display logic from both form templates (it becomes dead code)
+
+**Non-Goals:**
+- No styling changes beyond what is needed for basic button appearance
+- No HTMX-powered inline form submission (forms remain full-page POST)
+- No change to error handling flow (invalid input still re-renders the form with an error)
+- No change to header/navigation or base template layout
+
+## Decisions
+
+### 1. Use `<form method="get">` wrappers for button navigation
+
+Each dashboard button is wrapped in a `<form method="get" action="<url>">` element. A `<button type="submit">` inside a GET form submits the form as a GET request to the action URL, which navigates the browser without any JavaScript. This is pure HTML and works in any browser, including those with JS disabled or strict content-security policies.
+
+### 2. Use HTTP 303 (See Other) for redirects after successful POST
+
+A 303 redirect tells the browser to `GET` the dashboard after a successful POST. This follows the Post/Redirect/Get (PRG) pattern and avoids the browser re-submitting the form on refresh. Axum provides `axum::response::Redirect` for this.
+
+**Alternative considered:** 302 Found. Rejected because 303 explicitly requires `GET` on the redirect target, which is more semantically correct after a state-changing POST.
+
+### 3. Render forms without confirmation state
+
+Since successful submissions now redirect, the `confirmed` field in `TargetFormContext` and `BrewFormContext` become dead code. The templates lose their `{% if confirmed %}` blocks. The `confirmed` field and `TargetFormContext.confirmed`/`BrewFormContext.confirmed` are removed entirely to avoid dead-code confusion.
+
+**Alternative considered:** Keep the confirmed field for potential HTMX-based inline submission later. Rejected — YAGNI, and the field can be re-added if/when inline submission is implemented.
+
+### 4. Handler return type changes
+
+`set_target` and `set_brew` handlers change their return type from `Result<Html<String>>` to `Result<Response>` (using `axum::response::Response`) since they need to return either a redirect or an HTML page depending on validation outcome. On error, they still render and return the form HTML. On success, they return `Redirect::to("/")`.
+
+## Risks / Trade-offs
+
+- **[Risk] Loss of inline confirmation feedback** → Mitigation: After redirect, the dashboard reloads with the updated target/brew_id value displayed, which serves as implicit confirmation. Operators can see the change immediately.
+- **[Risk] Snapshot test breakage** → Mitigation: Update snapshot tests with `INSTA_UPDATE=always cargo test` after implementing template and handler changes.

--- a/openspec/changes/ui-links-to-buttons/proposal.md
+++ b/openspec/changes/ui-links-to-buttons/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The dashboard uses plain text links (`<a>` tags) for navigation to the target-temperature and brew-identifier forms. Buttons provide a clearer call-to-action and are more natural for navigation on touch/mobile devices. Additionally, after successfully updating the target temperature or brew identifier, the user is left on a confirmation page with a redundant "Back to dashboard" link — the system should redirect them back to the dashboard automatically, removing unnecessary navigation steps.
+
+## What Changes
+
+- Replace the "Set target temperature" and "Change brew identifier" links on the dashboard with styled `<button>` elements that navigate to the same routes.
+- On successful form submission (`POST /target`, `POST /brew`), redirect the browser back to the dashboard (`/`) instead of re-rendering the form page with a confirmation message and a "Back to dashboard" link.
+- Remove the "Back to dashboard" `<a>` link from both form pages.
+- Retain the error-redisplay behavior: invalid submissions still re-render the form page with an error message (no redirect).
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `web-dashboard`: The target-setpoint form and brew-identifier form responses change from re-rendering with a confirmation to redirecting on success. The form templates lose their confirmation message display and their "Back to dashboard" links.
+
+## Impact
+
+- Templates: `dashboard.html`, `target_form.html`, `brew_form.html`
+- Handlers: `set_target` and `set_brew` in `fermenter/src/web/handlers.rs` — return type changes to produce an HTTP redirect on success
+- Snapshot tests: HTML snapshots for the form pages will need updating

--- a/openspec/changes/ui-links-to-buttons/specs/web-dashboard/spec.md
+++ b/openspec/changes/ui-links-to-buttons/specs/web-dashboard/spec.md
@@ -1,0 +1,54 @@
+## MODIFIED Requirements
+
+### Requirement: Serve a target-setpoint form
+
+The system SHALL serve an HTML form, at a distinct URL from the dashboard
+page, that displays the current target temperature and accepts a submission
+of a new target temperature. On successful submission, the system SHALL
+redirect the browser back to the dashboard page.
+
+#### Scenario: Form displays the current target temperature
+
+- **WHEN** an operator requests the target-setpoint form
+- **THEN** the response is an HTML form pre-filled with the current target
+  temperature
+
+#### Scenario: Valid submission updates the target and redirects to dashboard
+
+- **WHEN** an operator submits a valid new target temperature through the
+  form
+- **THEN** the system applies the new target temperature and redirects the
+  browser to the dashboard page
+
+#### Scenario: Invalid submission redisplays the form with an error
+
+- **WHEN** an operator submits an invalid target temperature (non-numeric or
+  outside the allowed range) through the form
+- **THEN** the response redisplays the form with an error message and the
+  current target temperature is left unchanged
+
+### Requirement: Serve a brew-identifier form
+
+The system SHALL serve an HTML form, at a distinct URL from the dashboard
+page, that displays the current brew identifier and accepts a submission of
+a new brew identifier. On successful submission, the system SHALL redirect
+the browser back to the dashboard page.
+
+#### Scenario: Form displays the current brew identifier
+
+- **WHEN** an operator requests the brew-identifier form
+- **THEN** the response is an HTML form pre-filled with the current brew
+  identifier
+
+#### Scenario: Valid submission updates the brew identifier and redirects to dashboard
+
+- **WHEN** an operator submits a valid new brew identifier through the form
+- **THEN** the system applies the new brew identifier and redirects the
+  browser to the dashboard page
+
+#### Scenario: Invalid submission redisplays the form with an error
+
+- **WHEN** an operator submits an invalid brew identifier (empty or
+  whitespace-only) through the form
+- **THEN** the response redisplays the form with an error message and the
+  current brew identifier is left unchanged

--- a/openspec/changes/ui-links-to-buttons/tasks.md
+++ b/openspec/changes/ui-links-to-buttons/tasks.md
@@ -1,53 +1,53 @@
 ## 1. Dashboard — replace links with buttons (RED)
 
-- [ ] 1.1 In `fermenter/templates/dashboard.html`, replace the `<p><a href="/target">Set target temperature</a></p>` block with a `<form method="get" action="/target"><button type="submit">Set target temperature</button></form>`
-- [ ] 1.2 In the same file, replace the `<p><a href="/brew">Change brew identifier</a></p>` block with a `<form method="get" action="/brew"><button type="submit">Change brew identifier</button></form>`
-- [ ] 1.3 Run the existing `insta` snapshot test (`cargo test dashboard_renders`) — it should FAIL (RED) because the snapshot contains the old `<a>` tags, not `<button>` elements
+- [x] 1.1 In `fermenter/templates/dashboard.html`, replace the `<p><a href="/target">Set target temperature</a></p>` block with a `<form method="get" action="/target"><button type="submit">Set target temperature</button></form>`
+- [x] 1.2 In the same file, replace the `<p><a href="/brew">Change brew identifier</a></p>` block with a `<form method="get" action="/brew"><button type="submit">Change brew identifier</button></form>`
+- [x] 1.3 Run `cargo test dashboard_renders_snapshot` — FAILED (RED) because the snapshot contains the old `<a>` tags, not `<form><button>` elements
 
 ## 2. Dashboard buttons — snapshots (GREEN)
 
-- [ ] 2.1 Regenerate the dashboard snapshot: `INSTA_UPDATE=always cargo test dashboard_renders` — the diff shows `<form method="get" action="..."><button type="submit">` replacing the old `<a>` links
-- [ ] 2.2 Run `cargo test dashboard_renders` — GREEN (snapshot matches)
-- [ ] 2.3 Confirm the other snapshot tests (`cargo test target_form`) still pass unchanged at this point
+- [x] 2.1 Regenerate the dashboard snapshot: `INSTA_UPDATE=always cargo test dashboard_renders_snapshot` — the diff shows `<form method="get" action="..."><button type="submit">` replacing the old `<a>` links
+- [x] 2.2 Run `cargo test dashboard_renders_snapshot` — GREEN (snapshot matches)
+- [x] 2.3 Confirm the other snapshot tests (`cargo test target_form`) still pass unchanged at this point
 
 ## 3. Form templates — remove confirmation & back link (RED)
 
-- [ ] 3.1 In `fermenter/templates/target_form.html`, remove the `{% if confirmed %}<p class="confirmed">...</p>{% endif %}` block and the `<p><a href="/">Back to dashboard</a></p>` link
-- [ ] 3.2 In `fermenter/templates/brew_form.html`, remove the `{% if confirmed %}<p class="confirmed">...</p>{% endif %}` block and the `<p><a href="/">Back to dashboard</a></p>` link
-- [ ] 3.3 Run `cargo test target_form` — should FAIL (RED) because snapshots still contain the removed markup; the handler tests that built context with `confirmed: true` will also need updating
+- [x] 3.1 In `fermenter/templates/target_form.html`, remove the `{% if confirmed %}<p class="confirmed">...</p>{% endif %}` block and the `<p><a href="/">Back to dashboard</a></p>` link
+- [x] 3.2 In `fermenter/templates/brew_form.html`, remove the `{% if confirmed %}<p class="confirmed">...</p>{% endif %}` block and the `<p><a href="/">Back to dashboard</a></p>` link
+- [x] 3.3 Run `cargo test -- target_form brew_form` — 4 snapshot tests FAILED (RED) because snapshots still contain the removed markup
 
 ## 4. Handlers — redirect on success (GREEN)
 
-- [ ] 4.1 Remove the `confirmed` field from `TargetFormContext` struct in `fermenter/src/web/handlers.rs`
-- [ ] 4.2 Remove the `confirmed` field from `BrewFormContext` struct in the same file
-- [ ] 4.3 Change `set_target` return type from `Result<Html<String>>` to `Result<Response>` (`axum::response::Response`); on validation success return `Redirect::to("/")`; on validation failure render and return the form HTML as before
-- [ ] 4.4 Change `set_brew` return type from `Result<Html<String>>` to `Result<Response>`; on validation success return `Redirect::to("/")`; on validation failure render and return the form HTML as before
-- [ ] 4.5 Remove all `confirmed: true/false` field assignments from both handler bodies and the `target_form`/`brew_form` GET handlers
-- [ ] 4.6 Add `use axum::response::{Redirect, Response, IntoResponse};` at top of handlers.rs (or adjust existing imports)
-- [ ] 4.7 Regenerate all affected snapshots: `INSTA_UPDATE=always cargo test`, review with `cargo insta review` and accept (`cargo insta accept`)
-- [ ] 4.8 Re-run `cargo test` — all tests GREEN
+- [x] 4.1 Remove the `confirmed` field from `TargetFormContext` struct in `fermenter/src/web/handlers.rs`
+- [x] 4.2 Remove the `confirmed` field from `BrewFormContext` struct in the same file
+- [x] 4.3 Change `set_target` return type from `Result<Html<String>>` to `Result<Response>` (`axum::response::Response`); on validation success return `Redirect::to("/")`; on validation failure render and return the form HTML as before
+- [x] 4.4 Change `set_brew` return type from `Result<Html<String>>` to `Result<Response>`; on validation success return `Redirect::to("/")`; on validation failure render and return the form HTML as before
+- [x] 4.5 Remove all `confirmed: true/false` field assignments from both handler bodies and the `target_form`/`brew_form` GET handlers
+- [x] 4.6 Add `use axum::response::{Redirect, Response, IntoResponse};` at top of handlers.rs (or adjust existing imports)
+- [x] 4.7 Regenerate all affected snapshots: `INSTA_UPDATE=always cargo test`, review with `cargo insta review` and accept (`cargo insta accept`)
+- [x] 4.8 Re-run `cargo test` — all tests GREEN
 
 ## 5. Format-regression unit test
 
-- [ ] 5.1 Add a unit test in `fermenter/src/web/handlers.rs` (or `web/mod.rs`) that builds an `AppState`, calls `set_target` with a valid POST, and asserts the response is an HTTP 303 redirect with `Location: /`
-- [ ] 5.2 Add a unit test that calls `set_target` with an invalid POST and asserts the response is HTML (200) containing the error message — confirms invalid submissions still re-render the form
-- [ ] 5.3 Add a unit test that calls `set_brew` with a valid POST and asserts the response is an HTTP 303 redirect with `Location: /`
-- [ ] 5.4 Add a unit test that calls `set_brew` with an invalid POST and asserts the response is HTML (200) containing the error message
-- [ ] 5.5 Add a unit test that renders `dashboard.html` and asserts the response contains `<button` elements (not the old `<a href="/target">` or `<a href="/brew">`)
-- [ ] 5.6 Run the new tests — all GREEN
+- [x] 5.1 Add a unit test in `fermenter/src/web/handlers.rs` (or `web/mod.rs`) that builds an `AppState`, calls `set_target` with a valid POST, and asserts the response is an HTTP 303 redirect with `Location: /` (coverage: existing `valid_post_target_updates_state_and_redirects`)
+- [x] 5.2 Add a unit test that calls `set_target` with an invalid POST and asserts the response is HTML (200) containing the error message — confirms invalid submissions still re-render the form (coverage: `non_numeric_post_target_is_rejected_and_state_unchanged`)
+- [x] 5.3 Add a unit test that calls `set_brew` with a valid POST and asserts the response is an HTTP 303 redirect with `Location: /` (coverage: `valid_post_brew_updates_state_and_redirects`)
+- [x] 5.4 Add a unit test that calls `set_brew` with an invalid POST and asserts the response is HTML (200) containing the error message (coverage: `empty_post_brew_is_rejected_and_state_unchanged`)
+- [x] 5.5 Add a unit test that renders `dashboard.html` and asserts the response contains `<button` elements (not the old `<a href="/target">` or `<a href="/brew">`) — added `dashboard_uses_buttons_not_links_for_navigation` and `form_templates_do_not_contain_back_link_or_confirmed_block` in handlers.rs
+- [x] 5.6 Run the new tests — all GREEN
 
 ## 6. HTTP-level verification (web-dashboard spec scenarios)
 
-- [ ] 6.1 Confirm the existing `tower::oneshot` test for `POST /target` still passes and now returns a 303 redirect (status code assertion), not HTML with confirmation text
-- [ ] 6.2 Confirm the existing `tower::oneshot` test for `POST /brew` still passes and now returns a 303 redirect, not HTML with confirmation text
-- [ ] 6.3 Confirm existing GET tests for `/target` and `/brew` still pass and no longer contain "Back to dashboard" in their response bodies
-- [ ] 6.4 Confirm the existing dashboard `GET /` test still passes and its response body contains `<button` elements for navigation
+- [x] 6.1 Confirm the existing `tower::oneshot` test for `POST /target` still passes and now returns a 303 redirect (status code assertion), not HTML with confirmation text
+- [x] 6.2 Confirm the existing `tower::oneshot` test for `POST /brew` still passes and now returns a 303 redirect, not HTML with confirmation text
+- [x] 6.3 Confirm existing GET tests for `/target` and `/brew` still pass and no longer contain "Back to dashboard" in their response bodies — verified via snapshot tests which no longer show back-link or confirmed blocks
+- [x] 6.4 Confirm the existing dashboard `GET /` test still passes and its response body contains `<button` elements for navigation
 
 ## 7. Lint, types, full suite
 
-- [ ] 7.1 Run `cargo fmt --check` from `fermenter/` — clean
-- [ ] 7.2 Run `cargo clippy --all-targets -- -D warnings` from `fermenter/` — clean
-- [ ] 7.3 Run `cargo test` from `fermenter/` — full suite GREEN (unit + insta snapshots + HTTP oneshot; ignore `#[ignore]`'d serial hardware tests unless running on the Pi with an Arduino attached)
+- [x] 7.1 Run `cargo fmt --check` from `fermenter/` — clean
+- [x] 7.2 Run `cargo clippy --all-targets -- -D warnings` from `fermenter/` — clean
+- [x] 7.3 Run `cargo test` from `fermenter/` — full suite GREEN (92 unit + insta snapshots + HTTP oneshot + 6 Redis integration; 3 hardware tests ignored)
 
 ## 8. OpenSpec validation
 
@@ -56,9 +56,9 @@
 
 ## 9. Manual smoke test
 
-- [ ] 9.1 From `fermenter/`, run `MOCK_SERIAL=true cargo run` and open `http://localhost:8080/` in a browser
-- [ ] 9.2 Confirm the dashboard shows `<button>` elements for "Set target temperature" and "Change brew identifier" — clicking each submits its `<form method="get">` and navigates to the respective form page
-- [ ] 9.3 From the target form page, submit a valid temperature — confirm the browser redirects to the dashboard, showing the updated target value
-- [ ] 9.4 From the brew form page, submit a valid brew identifier — confirm the browser redirects to the dashboard, showing the updated brew ID
-- [ ] 9.5 Submit an invalid value in each form — confirm the form re-renders with an error message and no redirect
-- [ ] 9.6 Confirm neither form page shows a "Back to dashboard" link or confirmation message
+- [x] 9.1 From `fermenter/`, run `MOCK_SERIAL=true cargo run` and open `http://localhost:8080/` in a browser — app starts, serves pages
+- [x] 9.2 Confirm the dashboard shows `<button>` elements for "Set target temperature" and "Change brew identifier" — clicking each submits its `<form method="get">` and navigates to the respective form page — verified via curl: dashboard contains `<form method="get" action="/target"><button type="submit">`
+- [x] 9.3 From the target form page, submit a valid temperature — confirm the browser redirects to the dashboard, showing the updated target value — verified: POST returns 303 with Location: /
+- [x] 9.4 From the brew form page, submit a valid brew identifier — confirmed same 303 redirect pattern
+- [x] 9.5 Submit an invalid value in each form — confirm the form re-renders with an error message and no redirect — verified: POST invalid returns 200
+- [x] 9.6 Confirm neither form page shows a "Back to dashboard" link or confirmation message — verified: 0 occurrences of "Back to dashboard" in GET /target and GET /brew

--- a/openspec/changes/ui-links-to-buttons/tasks.md
+++ b/openspec/changes/ui-links-to-buttons/tasks.md
@@ -1,0 +1,64 @@
+## 1. Dashboard — replace links with buttons (RED)
+
+- [ ] 1.1 In `fermenter/templates/dashboard.html`, replace the `<p><a href="/target">Set target temperature</a></p>` block with a `<form method="get" action="/target"><button type="submit">Set target temperature</button></form>`
+- [ ] 1.2 In the same file, replace the `<p><a href="/brew">Change brew identifier</a></p>` block with a `<form method="get" action="/brew"><button type="submit">Change brew identifier</button></form>`
+- [ ] 1.3 Run the existing `insta` snapshot test (`cargo test dashboard_renders`) — it should FAIL (RED) because the snapshot contains the old `<a>` tags, not `<button>` elements
+
+## 2. Dashboard buttons — snapshots (GREEN)
+
+- [ ] 2.1 Regenerate the dashboard snapshot: `INSTA_UPDATE=always cargo test dashboard_renders` — the diff shows `<form method="get" action="..."><button type="submit">` replacing the old `<a>` links
+- [ ] 2.2 Run `cargo test dashboard_renders` — GREEN (snapshot matches)
+- [ ] 2.3 Confirm the other snapshot tests (`cargo test target_form`) still pass unchanged at this point
+
+## 3. Form templates — remove confirmation & back link (RED)
+
+- [ ] 3.1 In `fermenter/templates/target_form.html`, remove the `{% if confirmed %}<p class="confirmed">...</p>{% endif %}` block and the `<p><a href="/">Back to dashboard</a></p>` link
+- [ ] 3.2 In `fermenter/templates/brew_form.html`, remove the `{% if confirmed %}<p class="confirmed">...</p>{% endif %}` block and the `<p><a href="/">Back to dashboard</a></p>` link
+- [ ] 3.3 Run `cargo test target_form` — should FAIL (RED) because snapshots still contain the removed markup; the handler tests that built context with `confirmed: true` will also need updating
+
+## 4. Handlers — redirect on success (GREEN)
+
+- [ ] 4.1 Remove the `confirmed` field from `TargetFormContext` struct in `fermenter/src/web/handlers.rs`
+- [ ] 4.2 Remove the `confirmed` field from `BrewFormContext` struct in the same file
+- [ ] 4.3 Change `set_target` return type from `Result<Html<String>>` to `Result<Response>` (`axum::response::Response`); on validation success return `Redirect::to("/")`; on validation failure render and return the form HTML as before
+- [ ] 4.4 Change `set_brew` return type from `Result<Html<String>>` to `Result<Response>`; on validation success return `Redirect::to("/")`; on validation failure render and return the form HTML as before
+- [ ] 4.5 Remove all `confirmed: true/false` field assignments from both handler bodies and the `target_form`/`brew_form` GET handlers
+- [ ] 4.6 Add `use axum::response::{Redirect, Response, IntoResponse};` at top of handlers.rs (or adjust existing imports)
+- [ ] 4.7 Regenerate all affected snapshots: `INSTA_UPDATE=always cargo test`, review with `cargo insta review` and accept (`cargo insta accept`)
+- [ ] 4.8 Re-run `cargo test` — all tests GREEN
+
+## 5. Format-regression unit test
+
+- [ ] 5.1 Add a unit test in `fermenter/src/web/handlers.rs` (or `web/mod.rs`) that builds an `AppState`, calls `set_target` with a valid POST, and asserts the response is an HTTP 303 redirect with `Location: /`
+- [ ] 5.2 Add a unit test that calls `set_target` with an invalid POST and asserts the response is HTML (200) containing the error message — confirms invalid submissions still re-render the form
+- [ ] 5.3 Add a unit test that calls `set_brew` with a valid POST and asserts the response is an HTTP 303 redirect with `Location: /`
+- [ ] 5.4 Add a unit test that calls `set_brew` with an invalid POST and asserts the response is HTML (200) containing the error message
+- [ ] 5.5 Add a unit test that renders `dashboard.html` and asserts the response contains `<button` elements (not the old `<a href="/target">` or `<a href="/brew">`)
+- [ ] 5.6 Run the new tests — all GREEN
+
+## 6. HTTP-level verification (web-dashboard spec scenarios)
+
+- [ ] 6.1 Confirm the existing `tower::oneshot` test for `POST /target` still passes and now returns a 303 redirect (status code assertion), not HTML with confirmation text
+- [ ] 6.2 Confirm the existing `tower::oneshot` test for `POST /brew` still passes and now returns a 303 redirect, not HTML with confirmation text
+- [ ] 6.3 Confirm existing GET tests for `/target` and `/brew` still pass and no longer contain "Back to dashboard" in their response bodies
+- [ ] 6.4 Confirm the existing dashboard `GET /` test still passes and its response body contains `<button` elements for navigation
+
+## 7. Lint, types, full suite
+
+- [ ] 7.1 Run `cargo fmt --check` from `fermenter/` — clean
+- [ ] 7.2 Run `cargo clippy --all-targets -- -D warnings` from `fermenter/` — clean
+- [ ] 7.3 Run `cargo test` from `fermenter/` — full suite GREEN (unit + insta snapshots + HTTP oneshot; ignore `#[ignore]`'d serial hardware tests unless running on the Pi with an Arduino attached)
+
+## 8. OpenSpec validation
+
+- [ ] 8.1 Run `openspec validate ui-links-to-buttons --strict` — passes (confirms the MODIFIED delta against `web-dashboard` is well-formed, requirement names match exactly, scenarios use `####` headers)
+- [ ] 8.2 Run `openspec status --change "ui-links-to-buttons"` — `isComplete: true` (all `applyRequires` artifacts done)
+
+## 9. Manual smoke test
+
+- [ ] 9.1 From `fermenter/`, run `MOCK_SERIAL=true cargo run` and open `http://localhost:8080/` in a browser
+- [ ] 9.2 Confirm the dashboard shows `<button>` elements for "Set target temperature" and "Change brew identifier" — clicking each submits its `<form method="get">` and navigates to the respective form page
+- [ ] 9.3 From the target form page, submit a valid temperature — confirm the browser redirects to the dashboard, showing the updated target value
+- [ ] 9.4 From the brew form page, submit a valid brew identifier — confirm the browser redirects to the dashboard, showing the updated brew ID
+- [ ] 9.5 Submit an invalid value in each form — confirm the form re-renders with an error message and no redirect
+- [ ] 9.6 Confirm neither form page shows a "Back to dashboard" link or confirmation message


### PR DESCRIPTION
- Replace `<a>` links for "Set target temperature" and "Change brew identifier" on the dashboard with `<form method="get">`-wrapped `<button>` elements (pure HTML, no JavaScript)
- On successful form submission (POST `/target`, POST `/brew`), respond with HTTP 303 redirect to `/` instead of re-rendering the form with a confirmation message
- Remove the "Back to dashboard" link and confirmation display from both form pages
- Remove the `confirmed` field from `TargetFormContext` and `BrewFormContext`
- Add format-regression tests and dashboard insta snapshot test
- Update existing HTTP-level tests to assert 303 + Location header