### PR TITLE
Feature/docker buildkit cache mounts

### DIFF
--- a/fermenter/Dockerfile
+++ b/fermenter/Dockerfile
@@ -28,7 +28,10 @@ COPY src ./src
 COPY templates ./templates
 COPY static ./static
 
-RUN cargo build --release --features embed
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git/db \
+    --mount=type=cache,target=/app/target \
+    cargo build --release --features embed
 
 # ---- Runtime ---------------------------------------------------------------
 # debian:bookworm-slim over distroless (rewrite-plan.md §11 leaves this as an

--- a/fermenter/Dockerfile
+++ b/fermenter/Dockerfile
@@ -31,7 +31,8 @@ COPY static ./static
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git/db \
     --mount=type=cache,target=/app/target \
-    cargo build --release --features embed
+    cargo build --release --features embed && \
+    cp target/release/fermenter /app/fermenter
 
 # ---- Runtime ---------------------------------------------------------------
 # debian:bookworm-slim over distroless (rewrite-plan.md §11 leaves this as an
@@ -46,7 +47,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /app/target/release/fermenter /usr/local/bin/fermenter
+COPY --from=builder /app/fermenter /usr/local/bin/fermenter
 COPY --from=builder /app/static ./static
 
 EXPOSE 8080


### PR DESCRIPTION

This is to fix the long complication times when building the raspberry pi docker images.  This fix caches the build so only need to recompile any changed .rs file.