### PR TITLE
feat: show human-readable reason-code descriptions on the dashboard

### DIFF
--- a/fermenter/src/lib.rs
+++ b/fermenter/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod error;
 pub mod ingest;
 pub mod model;
+pub mod reason_code;
 pub mod serial;
 pub mod store;
 pub mod temperature_control;

--- a/fermenter/src/reason_code.rs
+++ b/fermenter/src/reason_code.rs
@@ -1,0 +1,236 @@
+use crate::model::Reading;
+
+/// Returns the human-readable description of a firmware reason code, or `None`
+/// if the code is unrecognized, empty, or an error sentinel (`RC_ERR`).
+///
+/// Source of truth: `arduino/TempController/TempControllerRules.md:27-58`.
+/// The descriptions below are copied verbatim from that table.
+pub fn reason_text(code: &str) -> Option<&'static str> {
+    match code {
+        // Failsafe range exceeded
+        "RC1" | "RC6" => Some(
+            "HEAT because the temperature is below the failsafe minimum, regardless of ambient conditions",
+        ),
+        "RC5" | "RC10" => Some(
+            "COOL because the temperature is above the failsafe maximum, regardless of ambient conditions",
+        ),
+        // With natural heating
+        "RC2.1" => Some(
+            "REST->REST because even though there is natural heating, the temperature is below the target range",
+        ),
+        "RC2.2" => Some(
+            "COOL->REST because temperature is below target range and there is natural heating",
+        ),
+        "RC2.3" => Some(
+            "HEAT->REST because temperature is below target range and there is natural heating",
+        ),
+        "RC3.1" => Some(
+            "REST->REST because we are in the target range.  There is natural heating so expect temperature to rise",
+        ),
+        "RC3.2" => Some(
+            "COOL->COOL because we are still within target range and we have natural heating (cooling overrun adjustment is used here)",
+        ),
+        "RC3.3" => Some(
+            "HEAT->REST because we are in the target range.  There is natural heating so expect temperature to rise",
+        ),
+        "RC4.1" => Some(
+            "REST->COOL because the temperature is above the target range and we have natural heating",
+        ),
+        "RC4.2" => Some(
+            "COOL->COOL becuase the temperature is above the target range and we have natural heating",
+        ),
+        "RC4.3" => Some(
+            "HEAT->COOL because the temperature is above target range and we have natural heating.  (adjust heating lag?)",
+        ),
+        // With natural cooling
+        "RC7.1" => Some(
+            "REST->HEAT because the temperature is below target range and there is natural cooling",
+        ),
+        "RC7.2" => Some(
+            "COOL->HEAT because the temperature is below the target range and there is natural cooling (adjust cooling lag?)",
+        ),
+        "RC7.3" => Some(
+            "HEAT->HEAT because the temperature is below target range and there is natural cooling",
+        ),
+        "RC8.1" => Some(
+            "REST->REST because the temperature is in the target range.  There is natural cooling so expect temperature to fall",
+        ),
+        "RC8.2" => Some(
+            "COOL->REST because the temperature is in the target range.  There is natural cooling so expect temperature to fall",
+        ),
+        "RC8.3" => Some(
+            "HEAT->HEAT because the temperature is still within target range and there is natural cooling",
+        ),
+        "RC9.1" => Some(
+            "REST->REST because the temperature is above target range and there is natural cooling",
+        ),
+        "RC9.2" => Some(
+            "COOL->COOL because the temperature is above target range and we'll continue cooling",
+        ),
+        "RC9.3" => Some(
+            "HEAT->REST because the temperature is above target range and there is natural cooling",
+        ),
+        _ => None,
+    }
+}
+
+pub fn reading_reason_text(reading: &Reading) -> Option<&'static str> {
+    reason_text(&reading.reason_code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_some(code: &str, expected: &str) {
+        let text = reason_text(code);
+        assert!(text.is_some(), "expected Some for code {code:?}, got None");
+        assert_eq!(text.unwrap(), expected, "mismatch for code {code:?}");
+    }
+
+    fn assert_none(code: &str) {
+        assert!(
+            reason_text(code).is_none(),
+            "expected None for code {code:?}, got Some"
+        );
+    }
+
+    #[test]
+    fn failsafe_codes() {
+        assert_some(
+            "RC1",
+            "HEAT because the temperature is below the failsafe minimum, regardless of ambient conditions",
+        );
+        assert_some(
+            "RC6",
+            "HEAT because the temperature is below the failsafe minimum, regardless of ambient conditions",
+        );
+        assert_some(
+            "RC5",
+            "COOL because the temperature is above the failsafe maximum, regardless of ambient conditions",
+        );
+        assert_some(
+            "RC10",
+            "COOL because the temperature is above the failsafe maximum, regardless of ambient conditions",
+        );
+    }
+
+    #[test]
+    fn natural_heating_codes() {
+        assert_some(
+            "RC2.1",
+            "REST->REST because even though there is natural heating, the temperature is below the target range",
+        );
+        assert_some(
+            "RC2.2",
+            "COOL->REST because temperature is below target range and there is natural heating",
+        );
+        assert_some(
+            "RC2.3",
+            "HEAT->REST because temperature is below target range and there is natural heating",
+        );
+        assert_some(
+            "RC3.1",
+            "REST->REST because we are in the target range.  There is natural heating so expect temperature to rise",
+        );
+        assert_some(
+            "RC3.2",
+            "COOL->COOL because we are still within target range and we have natural heating (cooling overrun adjustment is used here)",
+        );
+        assert_some(
+            "RC3.3",
+            "HEAT->REST because we are in the target range.  There is natural heating so expect temperature to rise",
+        );
+        assert_some(
+            "RC4.1",
+            "REST->COOL because the temperature is above the target range and we have natural heating",
+        );
+        assert_some(
+            "RC4.2",
+            "COOL->COOL becuase the temperature is above the target range and we have natural heating",
+        );
+        assert_some(
+            "RC4.3",
+            "HEAT->COOL because the temperature is above target range and we have natural heating.  (adjust heating lag?)",
+        );
+    }
+
+    #[test]
+    fn natural_cooling_codes() {
+        assert_some(
+            "RC7.1",
+            "REST->HEAT because the temperature is below target range and there is natural cooling",
+        );
+        assert_some(
+            "RC7.2",
+            "COOL->HEAT because the temperature is below the target range and there is natural cooling (adjust cooling lag?)",
+        );
+        assert_some(
+            "RC7.3",
+            "HEAT->HEAT because the temperature is below target range and there is natural cooling",
+        );
+        assert_some(
+            "RC8.1",
+            "REST->REST because the temperature is in the target range.  There is natural cooling so expect temperature to fall",
+        );
+        assert_some(
+            "RC8.2",
+            "COOL->REST because the temperature is in the target range.  There is natural cooling so expect temperature to fall",
+        );
+        assert_some(
+            "RC8.3",
+            "HEAT->HEAT because the temperature is still within target range and there is natural cooling",
+        );
+        assert_some(
+            "RC9.1",
+            "REST->REST because the temperature is above target range and there is natural cooling",
+        );
+        assert_some(
+            "RC9.2",
+            "COOL->COOL because the temperature is above target range and we'll continue cooling",
+        );
+        assert_some(
+            "RC9.3",
+            "HEAT->REST because the temperature is above target range and there is natural cooling",
+        );
+    }
+
+    #[test]
+    fn empty_and_error_sentinels() {
+        assert_none("");
+        assert_none("RC_ERR");
+    }
+
+    #[test]
+    fn unknown_code() {
+        assert_none("RC_FOO");
+        assert_none("RC99.9");
+        assert_none("garbage");
+    }
+
+    #[test]
+    fn reading_reason_text_delegates_correctly() {
+        let mut reading = Reading {
+            target: 19.5,
+            average: 18.7,
+            min: 18.0,
+            max: 19.0,
+            ambient: 20.1,
+            action: "heating".to_string(),
+            reason_code: String::new(),
+            json_size: None,
+        };
+        assert_eq!(reading_reason_text(&reading), None);
+
+        reading.reason_code = "RC3.1".to_string();
+        assert!(reading_reason_text(&reading).is_some());
+        assert!(
+            reading_reason_text(&reading)
+                .unwrap()
+                .contains("target range")
+        );
+
+        reading.reason_code = "RC_ERR".to_string();
+        assert_eq!(reading_reason_text(&reading), None);
+    }
+}

--- a/fermenter/src/web/handlers.rs
+++ b/fermenter/src/web/handlers.rs
@@ -11,6 +11,7 @@ use crate::brew_session::{persist_brew, validate_brew_id};
 use crate::error::Result;
 use crate::ingest;
 use crate::model::Reading;
+use crate::reason_code;
 use crate::temperature_control::{persist_target, validate_target};
 
 use super::AppState;
@@ -23,14 +24,20 @@ use super::render::render;
 #[derive(Serialize)]
 pub(crate) struct StatusContext {
     reading: Option<Reading>,
+    reason_text: Option<String>,
     brew_id: String,
     pub(crate) server_time: String,
 }
 
 pub(crate) fn status_context(state: &AppState) -> StatusContext {
     let reading = state.latest.lock().unwrap().clone();
+    let reason_text = reading
+        .as_ref()
+        .and_then(|r| reason_code::reason_text(&r.reason_code))
+        .map(str::to_owned);
     StatusContext {
         reading,
+        reason_text,
         brew_id: state.brew_tx.borrow().clone(),
         server_time: Local::now().format("%d-%b-%Y %H:%M:%S").to_string(),
     }
@@ -222,19 +229,35 @@ mod tests {
             max: 19.0,
             ambient: 20.1,
             action: "heating".to_string(),
-            reason_code: "below-target".to_string(),
+            reason_code: "RC3.1".to_string(),
             json_size: None,
+        }
+    }
+
+    fn sample_context() -> StatusContext {
+        let reading = sample_reading();
+        let reason_text = crate::reason_code::reason_text(&reading.reason_code).map(str::to_owned);
+        StatusContext {
+            reading: Some(reading),
+            reason_text,
+            brew_id: "00-TEST-v00".to_string(),
+            server_time: "14-Jul-2026 14:30:45".to_string(),
+        }
+    }
+
+    fn empty_context() -> StatusContext {
+        StatusContext {
+            reading: None,
+            reason_text: None,
+            brew_id: "00-TEST-v00".to_string(),
+            server_time: "14-Jul-2026 14:30:45".to_string(),
         }
     }
 
     #[test]
     fn status_fragment_with_reading_snapshot() {
         let env = build_environment();
-        let ctx = StatusContext {
-            reading: Some(sample_reading()),
-            brew_id: "00-TEST-v00".to_string(),
-            server_time: "14-Jul-2026 14:30:45".to_string(),
-        };
+        let ctx = sample_context();
         let html = render(&env, "partials/status.html", ctx).unwrap();
         insta::assert_snapshot!(html.0);
     }
@@ -242,11 +265,7 @@ mod tests {
     #[test]
     fn status_fragment_without_reading_snapshot() {
         let env = build_environment();
-        let ctx = StatusContext {
-            reading: None,
-            brew_id: "00-TEST-v00".to_string(),
-            server_time: "14-Jul-2026 14:30:45".to_string(),
-        };
+        let ctx = empty_context();
         let html = render(&env, "partials/status.html", ctx).unwrap();
         insta::assert_snapshot!(html.0);
     }
@@ -254,11 +273,7 @@ mod tests {
     #[test]
     fn dashboard_renders_snapshot() {
         let env = build_environment();
-        let ctx = StatusContext {
-            reading: Some(sample_reading()),
-            brew_id: "00-TEST-v00".to_string(),
-            server_time: "14-Jul-2026 14:30:45".to_string(),
-        };
+        let ctx = sample_context();
         let html = render(&env, "dashboard.html", ctx).unwrap();
         insta::assert_snapshot!(html.0);
     }
@@ -266,14 +281,14 @@ mod tests {
     #[test]
     fn status_fragment_includes_reason_code() {
         let env = build_environment();
-        let ctx = StatusContext {
-            reading: Some(sample_reading()),
-            brew_id: "00-TEST-v00".to_string(),
-            server_time: "14-Jul-2026 14:30:45".to_string(),
-        };
+        let ctx = sample_context();
         let html = render(&env, "partials/status.html", ctx).unwrap();
         assert!(html.0.contains("<dt>Reason</dt>"));
-        assert!(html.0.contains("<dd>below-target</dd>"));
+        assert!(html.0.contains("<dd>RC3.1"));
+        assert!(
+            html.0
+                .contains("REST-&gt;REST because we are in the target range")
+        );
     }
 
     #[test]
@@ -312,11 +327,7 @@ mod tests {
     #[test]
     fn dashboard_uses_buttons_not_links_for_navigation() {
         let env = build_environment();
-        let ctx = StatusContext {
-            reading: Some(sample_reading()),
-            brew_id: "00-TEST-v00".to_string(),
-            server_time: "14-Jul-2026 14:30:45".to_string(),
-        };
+        let ctx = sample_context();
         let html = render(&env, "dashboard.html", ctx).unwrap();
         assert!(html.0.contains("<button"), "dashboard must use buttons");
         assert!(

--- a/fermenter/src/web/handlers.rs
+++ b/fermenter/src/web/handlers.rs
@@ -292,6 +292,25 @@ mod tests {
     }
 
     #[test]
+    fn status_fragment_omits_reason_text_for_unmapped_codes() {
+        let env = build_environment();
+
+        for reason_code in ["RC_FOO", "", "RC_ERR"] {
+            let mut ctx = sample_context();
+            ctx.reading.as_mut().unwrap().reason_code = reason_code.to_string();
+            ctx.reason_text = None;
+
+            let html = render(&env, "partials/status.html", ctx).unwrap();
+            assert!(
+                html.0
+                    .contains(&format!("<dt>Reason</dt><dd>{reason_code}</dd>")),
+                "reason row did not contain only {reason_code:?}: {}",
+                html.0
+            );
+        }
+    }
+
+    #[test]
     fn target_form_with_current_target_snapshot() {
         let env = build_environment();
         let ctx = TargetFormContext {

--- a/fermenter/src/web/mod.rs
+++ b/fermenter/src/web/mod.rs
@@ -147,6 +147,8 @@ mod tests {
         }
     }
 
+    const RC3_1_REASON_TEXT: &str = "REST-&gt;REST because we are in the target range";
+
     async fn body_string(response: axum::response::Response) -> String {
         let bytes = response.into_body().collect().await.unwrap().to_bytes();
         String::from_utf8(bytes.to_vec()).unwrap()
@@ -171,6 +173,7 @@ mod tests {
         assert!(body.contains("18.7"));
         assert!(body.contains("Server time:"));
         assert!(body.contains("RC3.1"));
+        assert!(body.contains(RC3_1_REASON_TEXT));
     }
 
     #[tokio::test]
@@ -210,6 +213,30 @@ mod tests {
         assert!(body.contains(r#"id="status""#));
         assert!(body.contains("Server time:"));
         assert!(body.contains("RC3.1"));
+        assert!(body.contains(RC3_1_REASON_TEXT));
+    }
+
+    #[tokio::test]
+    async fn dashboard_and_status_omit_reason_text_for_unmapped_codes() {
+        for reason_code in ["RC_FOO", "", "RC_ERR"] {
+            let mut reading = sample_reading();
+            reading.reason_code = reason_code.to_string();
+
+            for path in ["/", "/status"] {
+                let router = build_router(test_state(Some(reading.clone())));
+                let response = router
+                    .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
+                    .await
+                    .unwrap();
+
+                assert_eq!(response.status(), StatusCode::OK);
+                let body = body_string(response).await;
+                assert!(
+                    body.contains(&format!("<dt>Reason</dt><dd>{reason_code}</dd>")),
+                    "{path} did not render only {reason_code:?}: {body}"
+                );
+            }
+        }
     }
 
     #[tokio::test]

--- a/fermenter/src/web/mod.rs
+++ b/fermenter/src/web/mod.rs
@@ -142,7 +142,7 @@ mod tests {
             max: 19.0,
             ambient: 20.1,
             action: "heating".to_string(),
-            reason_code: "below-target".to_string(),
+            reason_code: "RC3.1".to_string(),
             json_size: None,
         }
     }
@@ -170,7 +170,7 @@ mod tests {
         let body = body_string(response).await;
         assert!(body.contains("18.7"));
         assert!(body.contains("Server time:"));
-        assert!(body.contains("below-target"));
+        assert!(body.contains("RC3.1"));
     }
 
     #[tokio::test]
@@ -209,7 +209,7 @@ mod tests {
         assert!(body.contains("18.7"));
         assert!(body.contains(r#"id="status""#));
         assert!(body.contains("Server time:"));
-        assert!(body.contains("below-target"));
+        assert!(body.contains("RC3.1"));
     }
 
     #[tokio::test]

--- a/fermenter/src/web/snapshots/fermenter__web__handlers__tests__dashboard_renders_snapshot.snap
+++ b/fermenter/src/web/snapshots/fermenter__web__handlers__tests__dashboard_renders_snapshot.snap
@@ -24,7 +24,7 @@ expression: html.0
     
     <dl class="reading">
         <dt>Action</dt><dd>heating</dd>
-        <dt>Reason</dt><dd>below-target</dd>
+        <dt>Reason</dt><dd>RC3.1 — REST-&gt;REST because we are in the target range.  There is natural heating so expect temperature to rise</dd>
         <dt>Target</dt><dd>19.5&deg;</dd>
         <dt>Average</dt><dd>18.7&deg;</dd>
         <dt>Min</dt><dd>18.0&deg;</dd>

--- a/fermenter/src/web/snapshots/fermenter__web__handlers__tests__status_fragment_with_reading_snapshot.snap
+++ b/fermenter/src/web/snapshots/fermenter__web__handlers__tests__status_fragment_with_reading_snapshot.snap
@@ -8,7 +8,7 @@ expression: html.0
     
     <dl class="reading">
         <dt>Action</dt><dd>heating</dd>
-        <dt>Reason</dt><dd>below-target</dd>
+        <dt>Reason</dt><dd>RC3.1 — REST-&gt;REST because we are in the target range.  There is natural heating so expect temperature to rise</dd>
         <dt>Target</dt><dd>19.5&deg;</dd>
         <dt>Average</dt><dd>18.7&deg;</dd>
         <dt>Min</dt><dd>18.0&deg;</dd>

--- a/fermenter/templates/partials/status.html
+++ b/fermenter/templates/partials/status.html
@@ -4,7 +4,7 @@
     {% if reading %}
     <dl class="reading">
         <dt>Action</dt><dd>{{ reading.action }}</dd>
-        <dt>Reason</dt><dd>{{ reading["reason-code"] }}</dd>
+        <dt>Reason</dt><dd>{{ reading["reason-code"] }}{% if reason_text %} — {{ reason_text }}{% endif %}</dd>
         <dt>Target</dt><dd>{{ reading.target }}&deg;</dd>
         <dt>Average</dt><dd>{{ reading.average }}&deg;</dd>
         <dt>Min</dt><dd>{{ reading.min }}&deg;</dd>

--- a/openspec/changes/show-reason-code-text-on-dashboard/.openspec.yaml
+++ b/openspec/changes/show-reason-code-text-on-dashboard/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/show-reason-code-text-on-dashboard/design.md
+++ b/openspec/changes/show-reason-code-text-on-dashboard/design.md
@@ -1,0 +1,101 @@
+## Context
+
+The prior slice `2026-07-15-show-reason-code-on-dashboard` added a `Reason` row to the dashboard that renders the raw `reason-code` string emitted by the Arduino firmware (`RC1`, `RC3.1`, `RC5`, `RC_ERR`, …). That string is opaque to operators: understanding `RC3.1` requires opening `arduino/TempController/TempControllerRules.md` and matching the code against a table. The Rust side treats `reason_code` as a free-form `String` (`fermenter/src/model.rs:11`) with no enum, no `Display` impl, and no text mapping — the value flows untouched from serial → model → Redis → template.
+
+The canonical human-readable text for each code lives only in firmware docs: `arduino/TempController/TempControllerRules.md:27-58` is the authoritative table, with inline comments at each `setReasonCode(...)` call site in `ControllerActionRules.cpp` as a secondary source. There is no firmware-side `getReasonCodeText()` (the firmware has `Decision::getActionText()` at `arduino/TempController/Decision.cpp:13-28` as a precedent, but adding a firmware-side text API is out of scope and would risk the sacred serial contract).
+
+This slice closes that gap entirely on the Rust side by introducing a static code-to-text mapping and rendering the text alongside the code on the dashboard. It is the explicitly tracked follow-up recorded in `openspec/changes/archive/2026-07-15-show-reason-code-on-dashboard/design.md` and `BACKLOG.md:5`.
+
+Constraints inherited from the project:
+- The serial contract is sacred (`openspec/config.yaml:22-24`); this change MUST NOT alter the JSON shape or the `reason-code` field semantics.
+- MiniJinja templates load from disk in dev and are baked in via `--features embed` for the release image; any template change works in both modes with no new runtime file dependencies.
+- Bracket syntax `{{ reading["reason-code"] }}` is required in templates because the field is `#[serde(rename = "reason-code")]` (hyphenated key — dot access does not work in MiniJinja).
+- TDD red→green→refactor; insta snapshots guard HTML; CI runs `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Render a human-readable description next to the raw reason code in the dashboard `Reason` row and in the live-polled `/status` fragment, so operators can read the controller's rationale without leaving the UI.
+- Source the descriptions from a single Rust-side static mapping that mirrors `TempControllerRules.md:27-58`.
+- Handle unknown, empty, and error-sentinel codes gracefully by showing only the raw code (no fabricated text).
+- Keep the change Rust-side only: no serial, model, Redis, or firmware changes.
+- Keep the template logic-free; compute the text in the handler and pass it as context.
+
+**Non-Goals:**
+- Tooltip / popover UI for the description (a plain inline text suffix is sufficient).
+- Persisting the description to Redis Time Series (the raw code remains the stored source of truth; text is derived at render time).
+- Adding `getReasonCodeText()` to the Arduino firmware (would touch the sacred serial contract for no benefit — the mapping is a presentation concern).
+- Internationalization / multiple languages.
+- Auto-generating the Rust mapping from the firmware `.md` file at build time (the table is small and stable; a hand-maintained module with a unit test asserting coverage is simpler and avoids a build-time file dependency).
+- Changing the `Reading` struct shape or the API/JSON representation of readings.
+
+## Decisions
+
+### D1: Mapping lives in a new `fermenter/src/reason_code.rs` module
+
+**Choice:** A dedicated module exposing `pub fn reason_text(code: &str) -> Option<&'static str>`.
+
+**Rationale:** Keeps the mapping isolated from the model and web layers, is independently unit-testable, and avoids bloating `model.rs` or `handlers.rs`. A free function returning `Option<&'static str>` is the smallest surface that satisfies the template's needs and makes the "unknown code" case explicit in the type system.
+
+**Alternatives considered:**
+- *Method on `Reading` (e.g. `Reading::reason_text(&self)`):* couples the mapping to the model and requires a `Reading` instance to call, which is awkward for the no-reading path and for unit-testing the mapping in isolation. Rejected.
+- *Inline `match` in the handler:* scatters presentation logic in the web layer and is harder to test exhaustively. Rejected.
+- *A `ReasonCode` enum replacing the `String` field:* would require a custom `Deserialize` impl that handles unknown codes without failing (the firmware may emit new codes), and would touch the model/serial boundary. Out of scope for a presentation-only change. Rejected.
+
+### D2: Mapping returns `Option<&'static str>`; `None` covers empty, unknown, and `RC_ERR`
+
+**Choice:** `reason_text("")` → `None`; `reason_text("RC_ERR")` → `None`; `reason_text("RC_FOO")` (any unrecognized code) → `None`. Every code documented in `TempControllerRules.md:27-58` returns `Some(...)` with the verbatim table text. `RC6` and `RC10` are included even though they are not currently emitted by `ControllerActionRules.cpp`, because the rules table lists them as aliases of `RC1`/`RC5` and including them costs nothing.
+
+**Rationale:** The dashboard's behavior for the "no description available" case is then uniform: show the raw code alone. `RC_ERR` is a sentinel for an internal controller error; showing a fabricated "description" would be misleading, and the raw `RC_ERR` is itself meaningful to an operator. Mapping it to `None` means the UI shows `RC_ERR` with no trailing text — an honest signal that something is wrong rather than a soothing but invented sentence.
+
+**Alternatives considered:**
+- *Return `&'static str` with an "Unknown reason code" fallback:* rejected per the user's decision — the raw code alone is preferred so the operator sees the actual code for debugging and the absence of text is a visible prompt that the mapping needs updating.
+- *Map `RC_ERR` to a custom error string:* couples the Rust side to a firmware sentinel's meaning and risks drift. Rejected.
+
+### D3: Text is computed in `status_context()` and passed to the template as `reason_text: Option<String>`
+
+**Choice:** Add a field `reason_text: Option<String>` to `StatusContext` (`fermenter/src/web/handlers.rs:23-28`). In `status_context()` (`handlers.rs:30-37`), compute it from the latest reading: when `reading` is `Some(r)`, set `reason_text = reason_code::reason_text(&r.reason_code).map(str::to_owned)`; when there is no reading, leave it `None`.
+
+**Rationale:** Mirrors the existing pattern where `status_context()` assembles all display data and the template stays logic-free. Using `Option<String>` (rather than `Option<&str>`) keeps `StatusContext` owned and easy to pass into MiniJinja without lifetime juggling. Because `status_context()` feeds both the dashboard page and the `/status` fragment, both routes get the text for free and the "fragment matches dashboard" spec scenario continues to hold.
+
+**Alternatives considered:**
+- *Call `reason_text()` directly from the template via a method/global:* pushes logic into the template and requires registering a MiniJinja global/function. Rejected — the current architecture deliberately keeps templates logic-free.
+- *Add a `reason_text` field to `Reading`:* would change the model and leak presentation into the data layer. Rejected.
+
+### D4: Template renders `RC3.1 — <description>` in the existing `Reason` `<dd>`
+
+**Choice:** `fermenter/templates/partials/status.html:7` becomes:
+```
+<dt>Reason</dt><dd>{{ reading["reason-code"] }}{% if reason_text %} — {{ reason_text }}{% endif %}</dd>
+```
+Bracket syntax is retained for `reading["reason-code"]` (hyphenated key). An em-dash (` — `, space-emdash-space) separates the code from the description.
+
+**Rationale:** Keeps the raw code visible (preserves the prior slice's debug affordance and the existing spec requirement that the code be shown) while adding the human-readable text in the same cell. A single `<dd>` avoids adding a new row and keeps the reading `<dl>` compact. The `{% if reason_text %}` guard makes the no-description case render as just the raw code with no trailing dash.
+
+**Alternatives considered:**
+- *Replace the code with the text:* loses the debug affordance and weakens the existing spec requirement that the code be displayed. Rejected per the user's decision.
+- *Add a new `<dt>Reason (description)</dt>` row:* doubles the vertical footprint of the reading block for a secondary detail. Rejected per the user's decision.
+
+### D5: Update test fixtures from `"below-target"` to `"RC3.1"`
+
+**Choice:** Change `sample_reading()` in `fermenter/src/web/handlers.rs:225` and `fermenter/src/web/mod.rs:145` to emit `reason_code: "RC3.1".to_owned()` (and update the mock serial line in `fermenter/src/main.rs:122-125` only if its reason code is also `"below-target"` and asserted on — to be confirmed at implementation time). Update the literal `"below-target"` assertions in `handlers.rs:266-277` and `mod.rs:173, 212` to assert both `"RC3.1"` and the mapped description text. Refresh the two affected snapshots via `INSTA_UPDATE=always cargo test`.
+
+**Rationale:** `"below-target"` is not a real firmware code and would map to `None`, which would exercise only the fallback path and hide the text-rendering behavior in tests. Switching to `RC3.1` (a documented, currently-emitted code with a stable description) makes the tests assert the real mapping end-to-end.
+
+**Alternatives considered:**
+- *Add `"below-target"` as a synonym in the mapping:* pollutes the production mapping with a test-only string. Rejected per the user's decision.
+- *Keep `"below-target"` and have tests assert only the fallback:* leaves the text-rendering path untested at the snapshot/HTTP level. Rejected.
+
+### D6: Unit-test the mapping exhaustively, snapshot-test the rendering
+
+**Choice:** `fermenter/src/reason_code.rs` contains `#[cfg(test)] mod tests` with a case for every documented code (asserting the verbatim text), plus cases for `""`, `"RC_ERR"`, and an unknown `"RC_FOO"` asserting `None`. The dashboard/fragment rendering is covered by the existing insta snapshots (refreshed) and the updated HTTP/unit assertions.
+
+**Rationale:** Exhaustive unit coverage of the mapping catches drift between the Rust table and `TempControllerRules.md`; the snapshot tests catch template regressions. This matches the project's TDD and insta conventions.
+
+## Risks / Trade-offs
+
+- **[Mapping drift]** The Rust mapping and `TempControllerRules.md` can diverge if the firmware adds a code and the docs/Rust table are not updated in lockstep. → **Mitigation:** The mapping's unit tests enumerate every documented code; an unknown code renders as the raw code alone (a visible signal, not a crash). The mapping is small and changes rarely. Document the source-of-truth pointer (`TempControllerRules.md:27-58`) in a comment at the top of `reason_code.rs` so future editors know where to sync from.
+- **[Firmware emits an undocumented code]** If a future firmware build emits a code not in the Rust table, the dashboard shows only the raw code with no description. → **Mitigation:** This is the chosen fallback behavior, not a failure. The operator still sees the code; the missing text is a prompt to update the mapping. No incorrect text is ever shown.
+- **[Template change breaks embed builds]** A new template field that only works in dev (disk-loaded) but not in the baked-in release image would be a release blocker. → **Mitigation:** `reason_text` is plain string data on `StatusContext`, referenced with standard MiniJinja `{{ }}` syntax; no new template files, no runtime file deps. CI's build-only cross-compile job and the existing snapshot tests (which run against the same template loader) cover this. No new `--features embed` code path is introduced.
+- **[Snapshot churn]** Two snapshots change. → **Mitigation:** Low risk; `INSTA_UPDATE=always cargo test` then `cargo test` to confirm green, per `AGENTS.md`. The snapshot diff itself is a reviewable artifact.
+- **[Fixture churn across 3+ sites]** Updating `sample_reading()` in two files plus assertions could miss a site. → **Mitigation:** `grep` for `"below-target"` across `fermenter/` at implementation time to enumerate every occurrence before editing; the tasks list calls this out explicitly.

--- a/openspec/changes/show-reason-code-text-on-dashboard/proposal.md
+++ b/openspec/changes/show-reason-code-text-on-dashboard/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The dashboard already shows the raw `reason-code` (e.g. `RC3.1`) thanks to the prior `show-reason-code-on-dashboard` slice, but that opaque string is meaningless without cross-referencing `arduino/TempController/TempControllerRules.md`. When an operator sees unexpected heating or cooling, they have to leave the dashboard and look up the code in firmware docs to understand the controller's rationale. Adding the human-readable description inline closes that loop entirely in the UI. This is the explicitly-tracked follow-up from the prior slice (recorded in `openspec/changes/archive/2026-07-15-show-reason-code-on-dashboard/design.md` and `BACKLOG.md:5`).
+
+## What Changes
+
+- Introduce a static Rust mapping from each documented reason code (`RC1`, `RC2.1` … `RC9.3`, `RC5`, `RC10`) to its human-readable description, sourced from `arduino/TempController/TempControllerRules.md:27-58`.
+- Compute the description for the latest reading in the dashboard handler and pass it to the template as a new `reason_text` field on `StatusContext`.
+- Render the description in the existing `Reason` row of `partials/status.html`, in the same `<dd>` as the raw code, formatted `RC3.1 — <description>`.
+- When the code is unknown, empty, or `RC_ERR`, show only the raw code (no trailing text) — the operator still sees the code for debugging, and the gap is an honest signal that the mapping needs updating.
+- Update the Rust test fixtures that currently emit the non-firmware string `"below-target"` to emit a real firmware code (`RC3.1`), so tests exercise the real mapping.
+- Update affected snapshot and assertion tests to reflect the new markup and the real code.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- None: this change extends an existing capability's display behavior. -->
+
+### Modified Capabilities
+
+- `web-dashboard`: The dashboard and live-polled `/status` fragment SHALL additionally display a human-readable description of the current reason code, derived from a static code-to-text mapping, immediately alongside the raw code value. The description SHALL be omitted (leaving only the raw code) when the code is unrecognized, empty, or an error sentinel.
+
+## Impact
+
+- **New code:** `fermenter/src/reason_code.rs` — a static lookup `fn reason_text(code: &str) -> Option<&'static str>` plus unit tests covering every documented code, `RC_ERR`, the empty string, and an unknown code.
+- **Handler:** `fermenter/src/web/handlers.rs` — add `reason_text: Option<String>` to `StatusContext` and populate it in `status_context()`.
+- **Template:** `fermenter/templates/partials/status.html:7` — extend the `Reason` `<dd>` to append ` — {{ reason_text }}` when present.
+- **Tests:** `fermenter/src/web/handlers.rs` and `fermenter/src/web/mod.rs` — update `sample_reading()` fixtures and assertions from `"below-target"` to `"RC3.1"` plus its description.
+- **Snapshots:** `dashboard_renders_snapshot.snap` and `status_fragment_with_reading_snapshot.snap` — refreshed via `INSTA_UPDATE=always cargo test`.
+- **No impact** on the serial contract, `Reading` struct, Redis schema, firmware, or any API endpoint shape. The mapping is Rust-side only; the raw code remains the source of truth on the wire.

--- a/openspec/changes/show-reason-code-text-on-dashboard/specs/web-dashboard/spec.md
+++ b/openspec/changes/show-reason-code-text-on-dashboard/specs/web-dashboard/spec.md
@@ -1,0 +1,127 @@
+## MODIFIED Requirements
+
+### Requirement: Render a current-state dashboard page
+
+The system SHALL serve an HTML dashboard page over HTTP showing the current
+brew identifier and the most recently observed reading (average, min, max,
+ambient, target, action, and reason code), or an explicit no-data indication
+when no reading has been observed yet. The reason code SHALL be displayed
+immediately after the action, so the operator can see the controller's
+decision rationale. The system SHALL additionally display a human-readable
+description of the reason code, derived from a static code-to-text mapping,
+in the same cell as the raw code, formatted `<code> — <description>`. The
+description SHALL be omitted (leaving only the raw code) when the code is
+unrecognized, empty, or an error sentinel such as `RC_ERR`, so that the
+operator is never shown fabricated text for a code the mapping does not
+cover. The page SHALL also display a timestamp reflecting the server's
+local wall-clock time at render time, formatted
+`DD-MMM-YYYY HH:MM:SS` (e.g. `14-Jul-2026 14:30:45`), so an operator can
+distinguish a live server from a stale or frozen view. The timestamp SHALL
+render even when no reading has been observed yet.
+
+#### Scenario: Dashboard shows the latest reading
+
+- **WHEN** a browser requests the dashboard page and a reading has been
+  observed
+- **THEN** the response is an HTML page displaying the current brew
+  identifier and the latest reading's average, min, max, ambient, target,
+  action, and reason code values
+
+#### Scenario: Dashboard shows the reason code description alongside the code
+
+- **WHEN** a browser requests the dashboard page and the latest reading's
+  reason code has a known entry in the static code-to-text mapping
+- **THEN** the response is an HTML page whose `Reason` cell renders the raw
+  code followed by an em-dash and the human-readable description, in the
+  form `<code> — <description>`
+
+#### Scenario: Dashboard shows the raw code alone when no description is available
+
+- **WHEN** a browser requests the dashboard page and the latest reading's
+  reason code is unrecognized, empty, or an error sentinel such as `RC_ERR`
+- **THEN** the response is an HTML page whose `Reason` cell renders only the
+  raw code with no trailing em-dash or description, without error
+
+#### Scenario: Dashboard shows a no-data state before any reading arrives
+
+- **WHEN** a browser requests the dashboard page and no reading has been
+  observed yet
+- **THEN** the response is an HTML page indicating no reading is available
+  yet, without error
+
+#### Scenario: Dashboard displays the server's local time
+
+- **WHEN** a browser requests the dashboard page
+- **THEN** the response is an HTML page that includes a timestamp reflecting
+  the server's local wall-clock time at render time, formatted
+  `DD-MMM-YYYY HH:MM:SS`
+
+#### Scenario: Server time is shown before any reading arrives
+
+- **WHEN** a browser requests the dashboard page and no reading has been
+  observed yet
+- **THEN** the response still includes the server-local-time timestamp, so
+  the operator can confirm the server is alive even with no reading data
+
+### Requirement: Serve a live-polled current-state fragment
+
+The system SHALL serve an HTML fragment, at a distinct URL from the full
+dashboard page, containing only the current-state markup, so a browser can
+periodically re-fetch it and refresh the displayed state without a full page
+reload. The fragment SHALL include a timestamp reflecting the server's local
+wall-clock time at render time, formatted `DD-MMM-YYYY HH:MM:SS`, so the
+displayed time advances on each poll without a full page reload. When a
+reading has been observed, the fragment SHALL include the reason code
+immediately after the action value, together with its human-readable
+description derived from the same static code-to-text mapping used by the
+dashboard page, formatted `<code> — <description>`. The description SHALL
+be omitted (leaving only the raw code) when the code is unrecognized, empty,
+or an error sentinel such as `RC_ERR`.
+
+#### Scenario: Fragment reflects the latest state on each poll
+
+- **WHEN** a browser requests the status fragment after a new reading has
+  been observed since the previous request
+- **THEN** the fragment reflects the newly observed reading, including its
+  reason code and, when the code has a known mapping entry, the
+  human-readable description rendered in the same form as the dashboard page
+
+#### Scenario: Fragment shows the raw code alone when no description is available
+
+- **WHEN** a browser requests the status fragment and the latest reading's
+  reason code is unrecognized, empty, or an error sentinel such as `RC_ERR`
+- **THEN** the fragment renders only the raw code with no trailing em-dash
+  or description, without error
+
+#### Scenario: Fragment content matches the dashboard's embedded status block
+
+- **WHEN** the status fragment is requested directly and the dashboard page
+  is requested
+- **THEN** the current-state content rendered in both is equivalent for the
+  same underlying state, including the reason code and any description,
+  excluding the server-local-time field whose value is by design render-time
+  and therefore differs between the two responses
+
+#### Scenario: Dashboard page polls the fragment automatically
+
+- **WHEN** the dashboard page is loaded in a browser
+- **THEN** the page is configured to automatically re-request the status
+  fragment on an interval, without requiring a manual refresh
+
+#### Scenario: Fragment includes a server-time timestamp that refreshes on each poll
+
+- **WHEN** a browser requests the status fragment
+- **THEN** the fragment includes a timestamp reflecting the server's local
+  wall-clock time at render time, formatted `DD-MMM-YYYY HH:MM:SS`
+
+- **WHEN** the browser re-requests the status fragment on a subsequent poll
+  at least one second later
+- **THEN** the timestamp in the new response is greater than or equal to the
+  timestamp in the previous response, reflecting that it is recomputed on
+  each render
+
+#### Scenario: Fragment shows server time even with no reading
+
+- **WHEN** a browser requests the status fragment and no reading has been
+  observed yet
+- **THEN** the fragment still includes the server-local-time timestamp

--- a/openspec/changes/show-reason-code-text-on-dashboard/tasks.md
+++ b/openspec/changes/show-reason-code-text-on-dashboard/tasks.md
@@ -1,0 +1,42 @@
+## 1. Reason-code mapping module (red→green)
+
+- [x] 1.1 Create `fermenter/src/reason_code.rs` with a top-of-file comment pointing to `arduino/TempController/TempControllerRules.md:27-58` as the source of truth
+- [x] 1.2 Add `pub fn reason_text(code: &str) -> Option<&'static str>` returning `Some(<verbatim text>)` for every documented code: `RC1`, `RC6`, `RC5`, `RC10`, and `RC2.1`–`RC4.3`, `RC7.1`–`RC9.3` (text copied verbatim from `TempControllerRules.md:27-58`)
+- [x] 1.3 Ensure `reason_text("")`, `reason_text("RC_ERR")`, and any unrecognized code (e.g. `"RC_FOO"`) all return `None`
+- [x] 1.4 Add `#[cfg(test)] mod tests` with an assertion for every documented code (verbatim text), plus `""`, `"RC_ERR"`, and an unknown code asserting `None`
+- [x] 1.5 Register the module in `fermenter/src/main.rs` (or wherever the crate's `mod` declarations live) and run `cargo test reason_code` to confirm green
+
+## 2. Plumb the description into the dashboard context
+
+- [x] 2.1 Add `pub reason_text: Option<String>` to `StatusContext` in `fermenter/src/web/handlers.rs:23-28`
+- [x] 2.2 In `status_context()` (`handlers.rs:30-37`), set `reason_text` from the latest reading: `reason_code::reason_text(&r.reason_code).map(str::to_owned)` when a reading exists, `None` otherwise
+- [x] 2.3 Confirm both the `dashboard` handler (`GET /`) and the `status` handler (`GET /status`) receive the new field via the shared `StatusContext`
+
+## 3. Render the description in the status template
+
+- [x] 3.1 Edit `fermenter/templates/partials/status.html:7` to:
+  `<dt>Reason</dt><dd>{{ reading["reason-code"] }}{% if reason_text %} — {{ reason_text }}{% endif %}</dd>`
+- [x] 3.2 Verify the bracket syntax `reading["reason-code"]` is preserved (hyphenated key) and that `reason_text` uses plain dot access
+
+## 4. Update test fixtures to a real firmware code
+
+- [x] 4.1 `grep -rn "below-target" fermenter/` to enumerate every fixture/assertion site before editing
+- [x] 4.2 Update `sample_reading()` in `fermenter/src/web/handlers.rs:225` to use `reason_code: "RC3.1".to_owned()`
+- [x] 4.3 Update `sample_reading()` in `fermenter/src/web/mod.rs:145` to use `reason_code: "RC3.1".to_owned()`
+- [x] 4.4 Update any mock-serial reason-code fixture (e.g. `fermenter/src/main.rs:122-125`) if it asserts `"below-target"` — confirm via the grep in 4.1
+- [x] 4.5 Update the literal assertion in `status_fragment_includes_reason_code` (`handlers.rs:266-277`) to assert both `"RC3.1"` and the mapped description text
+- [x] 4.6 Update the HTTP-body assertions in `fermenter/src/web/mod.rs:173, 212` to assert `"RC3.1"` (and the description where appropriate)
+
+## 5. Snapshot refresh and full verification
+
+- [x] 5.1 Run `INSTA_UPDATE=always cargo test` from `fermenter/` to refresh `dashboard_renders_snapshot.snap` and `status_fragment_with_reading_snapshot.snap`
+- [x] 5.2 Re-run `cargo test` from `fermenter/` and confirm all tests green (including the no-reading snapshot, which should be unaffected)
+- [x] 5.3 Run `cargo fmt --check` from `fermenter/` and fix any formatting
+- [x] 5.4 Run `cargo clippy --all-targets -- -D warnings` from `fermenter/` and fix any lints
+- [x] 5.5 Visually diff the two refreshed snapshots to confirm the `Reason` cell now reads `RC3.1 — REST->REST because we are in the target range.  There is natural heating so expect temperature to rise` (or equivalent) and that the no-reading snapshot is unchanged
+
+## 6. Spec sync and self-check
+
+- [x] 6.1 Confirm the implementation satisfies both MODIFIED requirements in `specs/web-dashboard/spec.md` (dashboard page and `/status` fragment show code + description; unknown/empty/`RC_ERR` shows code alone)
+- [x] 6.2 Confirm no changes were made to the serial contract, `Reading` struct shape, Redis schema, API JSON shape, or any firmware file
+- [x] 6.3 Confirm the change works under both `cargo run` (disk templates) and `--features embed` (no new runtime file deps introduced)

--- a/openspec/changes/show-reason-code-text-on-dashboard/tasks.md
+++ b/openspec/changes/show-reason-code-text-on-dashboard/tasks.md
@@ -1,42 +1,73 @@
-## 1. Reason-code mapping module (red→green)
+## Historical TDD note
 
-- [x] 1.1 Create `fermenter/src/reason_code.rs` with a top-of-file comment pointing to `arduino/TempController/TempControllerRules.md:27-58` as the source of truth
-- [x] 1.2 Add `pub fn reason_text(code: &str) -> Option<&'static str>` returning `Some(<verbatim text>)` for every documented code: `RC1`, `RC6`, `RC5`, `RC10`, and `RC2.1`–`RC4.3`, `RC7.1`–`RC9.3` (text copied verbatim from `TempControllerRules.md:27-58`)
-- [x] 1.3 Ensure `reason_text("")`, `reason_text("RC_ERR")`, and any unrecognized code (e.g. `"RC_FOO"`) all return `None`
-- [x] 1.4 Add `#[cfg(test)] mod tests` with an assertion for every documented code (verbatim text), plus `""`, `"RC_ERR"`, and an unknown code asserting `None`
-- [x] 1.5 Register the module in `fermenter/src/main.rs` (or wherever the crate's `mod` declarations live) and run `cargo test reason_code` to confirm green
+The original completed checklist did not record either pre-implementation RED
+run. Those executions cannot be verified or truthfully backfilled after the
+implementation exists. The RED checkpoints below document the required process
+for this change.
+
+## 1. Reason-code mapping module (RED -> GREEN)
+
+- [x] 1.1 Add table-driven `#[cfg(test)]` cases for every documented code, asserting its verbatim `TempControllerRules.md:27-58` text, plus `""`, `"RC_ERR"`, and unknown codes asserting `None`
+Historical RED checkpoint: before implementing the lookup table, the new
+mapping tests should have been run with `cargo test reason_code` and confirmed
+to fail. This execution was not recorded and cannot be reconstructed now.
+- [x] 1.3 Create `fermenter/src/reason_code.rs` with a source-of-truth comment pointing to `arduino/TempController/TempControllerRules.md:27-58`
+- [x] 1.4 Add `pub fn reason_text(code: &str) -> Option<&'static str>` returning verbatim text for `RC1`, `RC6`, `RC5`, `RC10`, `RC2.1`-`RC4.3`, and `RC7.1`-`RC9.3`; return `None` for unrecognized, empty, and `RC_ERR` codes
+- [x] 1.5 Register the module in `fermenter/src/main.rs` (or the crate's module declarations) and run `cargo test reason_code` to confirm GREEN
 
 ## 2. Plumb the description into the dashboard context
 
-- [x] 2.1 Add `pub reason_text: Option<String>` to `StatusContext` in `fermenter/src/web/handlers.rs:23-28`
-- [x] 2.2 In `status_context()` (`handlers.rs:30-37`), set `reason_text` from the latest reading: `reason_code::reason_text(&r.reason_code).map(str::to_owned)` when a reading exists, `None` otherwise
-- [x] 2.3 Confirm both the `dashboard` handler (`GET /`) and the `status` handler (`GET /status`) receive the new field via the shared `StatusContext`
+- [x] 2.1 Add `reason_text: Option<String>` to `StatusContext` in `fermenter/src/web/handlers.rs`
+- [x] 2.2 In `status_context()`, derive the field from the latest reading with `reason_code::reason_text(&r.reason_code).map(str::to_owned)` and use `None` when no reading exists
+- [x] 2.3 Confirm the shared `StatusContext` supplies the field to both the dashboard handler (`GET /`) and status handler (`GET /status`)
 
-## 3. Render the description in the status template
+## 3. Render the description in the status template (RED)
 
-- [x] 3.1 Edit `fermenter/templates/partials/status.html:7` to:
-  `<dt>Reason</dt><dd>{{ reading["reason-code"] }}{% if reason_text %} — {{ reason_text }}{% endif %}</dd>`
-- [x] 3.2 Verify the bracket syntax `reading["reason-code"]` is preserved (hyphenated key) and that `reason_text` uses plain dot access
+- [x] 3.1 Edit `fermenter/templates/partials/status.html` so its existing Reason `<dd>` renders `{{ reading["reason-code"] }}{% if reason_text %} — {{ reason_text }}{% endif %}`
+- [x] 3.2 Preserve bracket access for the hyphenated `reading["reason-code"]` key and use ordinary dot access for `reason_text`
+Historical RED checkpoint: after the template change and before snapshot
+acceptance, `cargo test status_fragment_with_reading_snapshot` should have
+failed because the snapshot lacked the description. This execution was not
+recorded and cannot be reconstructed now.
 
-## 4. Update test fixtures to a real firmware code
+## 4. Snapshot update (GREEN)
 
-- [x] 4.1 `grep -rn "below-target" fermenter/` to enumerate every fixture/assertion site before editing
-- [x] 4.2 Update `sample_reading()` in `fermenter/src/web/handlers.rs:225` to use `reason_code: "RC3.1".to_owned()`
-- [x] 4.3 Update `sample_reading()` in `fermenter/src/web/mod.rs:145` to use `reason_code: "RC3.1".to_owned()`
-- [x] 4.4 Update any mock-serial reason-code fixture (e.g. `fermenter/src/main.rs:122-125`) if it asserts `"below-target"` — confirm via the grep in 4.1
-- [x] 4.5 Update the literal assertion in `status_fragment_includes_reason_code` (`handlers.rs:266-277`) to assert both `"RC3.1"` and the mapped description text
-- [x] 4.6 Update the HTTP-body assertions in `fermenter/src/web/mod.rs:173, 212` to assert `"RC3.1"` (and the description where appropriate)
+- [x] 4.1 Search `fermenter/` for `"below-target"` to enumerate all fixture and assertion sites before updating them
+- [x] 4.2 Update `sample_reading()` in `fermenter/src/web/handlers.rs` and `fermenter/src/web/mod.rs` to use `reason_code: "RC3.1".to_owned()`
+- [x] 4.3 Update any asserted mock-serial `"below-target"` fixture discovered by the search
+- [x] 4.4 Regenerate `dashboard_renders_snapshot.snap` and `status_fragment_with_reading_snapshot.snap` with `INSTA_UPDATE=always cargo test`
+- [x] 4.5 Re-run the affected snapshot tests and confirm GREEN; confirm the no-reading snapshot remains unchanged
+- [x] 4.6 Review the refreshed snapshots and confirm the Reason cell contains `RC3.1` followed by its mapped description
 
-## 5. Snapshot refresh and full verification
+## 5. Format-regression unit tests
 
-- [x] 5.1 Run `INSTA_UPDATE=always cargo test` from `fermenter/` to refresh `dashboard_renders_snapshot.snap` and `status_fragment_with_reading_snapshot.snap`
-- [x] 5.2 Re-run `cargo test` from `fermenter/` and confirm all tests green (including the no-reading snapshot, which should be unaffected)
-- [x] 5.3 Run `cargo fmt --check` from `fermenter/` and fix any formatting
-- [x] 5.4 Run `cargo clippy --all-targets -- -D warnings` from `fermenter/` and fix any lints
-- [x] 5.5 Visually diff the two refreshed snapshots to confirm the `Reason` cell now reads `RC3.1 — REST->REST because we are in the target range.  There is natural heating so expect temperature to rise` (or equivalent) and that the no-reading snapshot is unchanged
+- [x] 5.1 Update `status_fragment_includes_reason_code` in `fermenter/src/web/handlers.rs` to render the status partial with `RC3.1` and assert both the Reason label/code and mapped description are present
+- [x] 5.2 Add a rendered-template regression test for an unknown code, `""`, and `"RC_ERR"`, asserting each displays the raw code without a separator or fabricated description
+- [x] 5.3 Run the format-regression unit tests and confirm GREEN
 
-## 6. Spec sync and self-check
+## 6. HTTP-level verification (web-dashboard spec scenarios)
 
-- [x] 6.1 Confirm the implementation satisfies both MODIFIED requirements in `specs/web-dashboard/spec.md` (dashboard page and `/status` fragment show code + description; unknown/empty/`RC_ERR` shows code alone)
-- [x] 6.2 Confirm no changes were made to the serial contract, `Reading` struct shape, Redis schema, API JSON shape, or any firmware file
-- [x] 6.3 Confirm the change works under both `cargo run` (disk templates) and `--features embed` (no new runtime file deps introduced)
+- [x] 6.1 In `status_returns_ok_with_latest_reading`, assert the `GET /status` body contains both `RC3.1` and its mapped description
+- [x] 6.2 In `dashboard_returns_ok_with_embedded_status_content`, assert the `GET /` body contains both `RC3.1` and its mapped description
+- [x] 6.3 Add HTTP-level coverage that an unknown, empty, or `RC_ERR` code renders the raw code alone with no trailing separator or description
+- [x] 6.4 Run the affected `tower::oneshot` tests and confirm GREEN
+
+## 7. Lint, types, and full suite
+
+- [x] 7.1 Run `cargo fmt --check` from `fermenter/` and fix formatting
+- [x] 7.2 Run `cargo clippy --all-targets -- -D warnings` from `fermenter/` and fix lints
+- [x] 7.3 Run `cargo test` from `fermenter/` and confirm the full suite is GREEN
+- [x] 7.4 Run `cargo build --features embed` from `fermenter/` to verify the baked-template build path
+
+## 8. OpenSpec validation and self-check
+
+- [x] 8.1 Run `openspec validate show-reason-code-text-on-dashboard --strict`
+- [x] 8.2 Run `openspec status --change "show-reason-code-text-on-dashboard"` and confirm `isComplete: true`
+- [x] 8.3 Confirm the implementation satisfies both MODIFIED `web-dashboard` requirements: dashboard and `/status` show code plus description, while unknown/empty/`RC_ERR` show the code alone
+- [x] 8.4 Confirm no serial-contract, `Reading` shape, Redis schema, API JSON shape, or firmware changes were made
+
+## 9. Manual smoke test
+
+- [x] 9.1 From `fermenter/`, run `MOCK_SERIAL=true cargo run` and request the dashboard in a browser or with a local HTTP client
+- [x] 9.2 Confirm the dashboard Reason cell renders the mapped terminal `RC1` mock reading during the feed's pause; deterministic tests cover the `RC3.1` fixture
+- [x] 9.3 Confirm an unknown/error/empty reason code, when injected through the test path, displays only the raw code with no dangling separator


### PR DESCRIPTION
### Summary
- Add a Rust-side mapping for documented Arduino reason codes to their operator-readable descriptions.
- Display Reason as <code> — <description> on both the dashboard and live /status fragment.
- Preserve raw-code-only output for unknown, empty, and RC_ERR values.
- Replace non-firmware test fixtures with RC3.1, refresh snapshots, and add mapping, rendering, and HTTP regression coverage.
- Add OpenSpec proposal, design, specification delta, and completed task record.

### Scope
No changes to the serial contract, firmware, Reading model, Redis schema, or API shape.

### Validation
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test
- cargo build --features embed
- openspec validate show-reason-code-text-on-dashboard --strict