### PR TITLE
feat: deploy release images by SemVer tag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,5 +19,5 @@
 - **Snapshot tests:** `fermenter/src/web/handlers.rs` uses `insta::assert_snapshot!` for HTML fragments (snapshots in `fermenter/src/web/snapshots/`). After changing templates, update snapshots with `INSTA_UPDATE=always cargo test` or `cargo insta accept`.
 
 ## Deployment
-- **Cross-compile + ship to Pi:** `scripts/build_and_ship_image.sh pi@<host>` builds `fermenter:arm64` via QEMU (`docker buildx build --platform linux/arm64`), saves it to a tarball, and scp's it to the Pi. Then on the Pi: `gunzip -c fermenter-arm64.tar.gz | docker load && docker compose up -d` — Compose's `image:` + `build:` picks up the loaded image without rebuilding.
+- **Cross-compile + ship to Pi:** From an annotated SemVer Git tag, `scripts/build_and_ship_image.sh pi@<host>` builds `fermenter:<tag>` via QEMU (`docker buildx build --platform linux/arm64`), saves it to a tarball, and scp's it to the Pi. Then on the Pi: `gunzip -c fermenter-<tag>.tar.gz | docker load && FERMENTER_IMAGE_TAG=<tag> docker compose up -d` — Compose's `image:` + `build:` picks up the loaded image without rebuilding.
 </content>

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -189,4 +189,22 @@ docker compose logs fermenter -f  # tail the app only
 ```
 
 To change the target temperature or brew ID at runtime, use the web dashboard at `http://<pi-ip>:8080` rather than editing `fermenter/.env` — changes made through the dashboard take effect immediately without a restart.
+
+### Deploy a release built elsewhere
+
+Create an annotated SemVer tag at the release commit, then run the shipping script
+from the development machine:
+
+```bash
+git tag -a v2.0.0 -m "Fermenter v2.0.0"
+git push origin v2.0.0
+./scripts/build_and_ship_image.sh pi@<pi-host>
+```
+
+On the Pi, load the transferred archive and select its exact image tag:
+
+```bash
+gunzip -c ~/fermenter-v2.0.0.tar.gz | docker load
+FERMENTER_IMAGE_TAG=v2.0.0 docker compose up -d
+```
 </content>

--- a/compose.yaml
+++ b/compose.yaml
@@ -15,16 +15,18 @@ services:
     command: redis-server --save 60 1
 
   fermenter:
-    # `image:` alongside `build:` means: if `fermenter:arm64` already exists
+    # `image:` alongside `build:` means: if the selected image already exists
     # locally (e.g. `docker load`-ed from a `docker buildx build --platform
-    # linux/arm64 -t fermenter:arm64` built on the dev machine, per the
+    # linux/arm64 -t fermenter:v2.0.0` built on the dev machine, per the
     # Dockerfile header), `docker compose up` uses it as-is with no build
     # step. If it's absent, `docker compose build`/`up --build` builds it
     # from `context: fermenter` and tags it fermenter:arm64 (fine on the Pi
     # itself, since it's natively arm64 there — no QEMU needed for a
     # Pi-native build; QEMU is only needed when cross-building from an
     # x86_64 dev machine).
-    image: fermenter:arm64
+    # Set FERMENTER_IMAGE_TAG when deploying a released image. The arm64
+    # default supports local, Pi-native builds outside the release workflow.
+    image: fermenter:${FERMENTER_IMAGE_TAG:-arm64}
     build:
       context: fermenter
     env_file: fermenter/.env

--- a/scripts/build_and_ship_image.sh
+++ b/scripts/build_and_ship_image.sh
@@ -14,12 +14,14 @@
 # next step.
 #
 # Usage:
+#   git tag -a v2.0.0 -m "Fermenter v2.0.0"
 #   ./scripts/build_and_ship_image.sh pi@raspberrypi.local
 #   PI_HOST=pi@raspberrypi.local ./scripts/build_and_ship_image.sh
 #
 # Optional environment overrides:
 #   IMAGE_NAME    (default: fermenter)
-#   IMAGE_TAG     (default: arm64)
+#   IMAGE_TAG     (default: the annotated SemVer Git tag at HEAD; use only for
+#                  non-release/test builds, e.g. IMAGE_TAG=arm64)
 #   PLATFORM      (default: linux/arm64)
 #   BUILDER_NAME  (default: fermenter-builder)
 #   REMOTE_PATH   (default: ~/)
@@ -31,8 +33,9 @@
 
 set -euo pipefail
 
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
 IMAGE_NAME="${IMAGE_NAME:-fermenter}"
-IMAGE_TAG="${IMAGE_TAG:-arm64}"
 PLATFORM="${PLATFORM:-linux/arm64}"
 BUILDER_NAME="${BUILDER_NAME:-fermenter-builder}"
 REMOTE_PATH="${REMOTE_PATH:-~/}"
@@ -44,7 +47,25 @@ if [[ -z "$PI_HOST" ]]; then
   exit 1
 fi
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ -z "${IMAGE_TAG:-}" ]]; then
+  IMAGE_TAG="$(git -C "$REPO_ROOT" describe --exact-match --tags 2>/dev/null || true)"
+  if [[ -z "$IMAGE_TAG" ]]; then
+    echo "HEAD must have an annotated SemVer Git tag (for example, v2.0.0)." >&2
+    echo "Create and check out the release tag, or set IMAGE_TAG for a non-release/test build." >&2
+    exit 1
+  fi
+
+  if [[ "$(git -C "$REPO_ROOT" for-each-ref --format='%(objecttype)' "refs/tags/$IMAGE_TAG")" != "tag" ]]; then
+    echo "Release tag '$IMAGE_TAG' must be annotated." >&2
+    exit 1
+  fi
+
+  if [[ ! "$IMAGE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+    echo "Release tag '$IMAGE_TAG' must use SemVer (for example, v2.0.0)." >&2
+    exit 1
+  fi
+fi
+
 IMAGE_REF="${IMAGE_NAME}:${IMAGE_TAG}"
 ARCHIVE_NAME="${IMAGE_NAME}-${IMAGE_TAG}.tar.gz"
 
@@ -78,7 +99,7 @@ cat <<EOF
 ==> Done. On the Pi, run:
 
     gunzip -c ${REMOTE_PATH%/}/${ARCHIVE_NAME} | docker load
-    cd /path/to/fermenter-temp-controller && docker compose up -d
+    cd /path/to/fermenter-temp-controller && FERMENTER_IMAGE_TAG=${IMAGE_TAG} docker compose up -d
 
 (docker compose up -d picks up the freshly loaded ${IMAGE_REF} image
 without rebuilding, since compose.yaml's fermenter service has both


### PR DESCRIPTION
### Summary
- Require the image-shipping script to derive its image tag from an annotated SemVer tag at HEAD.
- Reject lightweight, non-SemVer, or missing release tags unless IMAGE_TAG is explicitly overridden for test/non-release builds.
- Configure Compose to select a release image with FERMENTER_IMAGE_TAG, while retaining arm64 for Pi-native local builds.
- Update the Pi deployment instructions, including the exact archive name and Compose command.
- Update repository deployment guidance to reflect the tag-based release workflow.


### Example release flow
git tag -a v2.0.0 -m "Fermenter v2.0.0"
git push origin v2.0.0
./scripts/build_and_ship_image.sh pi@<pi-host>
On the Pi:
gunzip -c ~/fermenter-v2.0.0.tar.gz | docker load
FERMENTER_IMAGE_TAG=v2.0.0 docker compose up -d

### Scope
No application, firmware, serial-contract, or Redis-schema changes.