### PR TITLE
Document espflash prerequisite and TMPDIR workaround in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -214,9 +214,23 @@ FERMENTER_IMAGE_TAG=v2.0.0 docker compose up -d
 
 ### Deploy a firmware update built elsewhere
 
-Same shape as the app image above: build and validate the firmware on your
-dev machine as usual (`firmware/README.md`), then ship the compiled binary
-to the Pi:
+One-time prerequisite on the Pi: install `espflash`, the tool that writes
+the binary to the board. It doesn't need the embedded ESP32 toolchain
+(that's only for *building* firmware, done on the dev machine) — just Rust
+and Cargo:
+
+```bash
+cargo install espflash
+```
+
+(No Rust/Cargo on the Pi? Grab a prebuilt binary from the
+[espflash releases page](https://github.com/esp-rs/espflash/releases)
+— the `aarch64-unknown-linux-gnu` build — instead of installing a full
+toolchain just for this one tool.)
+
+Then, same shape as the app image above: build and validate the firmware on
+your dev machine as usual (`firmware/README.md`), then ship the compiled
+binary to the Pi:
 
 ```bash
 ./scripts/build_and_ship_firmware.sh pi@<pi-host>

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -228,6 +228,15 @@ cargo install espflash
 — the `aarch64-unknown-linux-gnu` build — instead of installing a full
 toolchain just for this one tool.)
 
+**`/tmp` too small for the build?** Cargo builds in `TMPDIR` (falls back to
+`/tmp`), which on some Pi setups is a small RAM-backed `tmpfs`. Point it at
+the SD card instead:
+
+```bash
+mkdir -p ~/cargo-tmp
+TMPDIR=~/cargo-tmp cargo install espflash
+```
+
 Then, same shape as the app image above: build and validate the firmware on
 your dev machine as usual (`firmware/README.md`), then ship the compiled
 binary to the Pi:


### PR DESCRIPTION
## Summary

  Small follow-up to the ESP32-C3 firmware rewrite (#60), found while actually testing `scripts/build_and_ship_firmware.sh` against a real Pi.

  - `INSTALL.md`'s "Deploy a firmware update built elsewhere" section assumed `espflash` was already on the Pi, but nothing in the setup steps ever installs it. Added a one-time prerequisite: `cargo install
  espflash` (clarifying it only needs Rust/Cargo, not the full embedded ESP32 toolchain — that's for *building* firmware, done on the dev machine), plus a prebuilt-binary alternative for a Pi without Rust
  installed.
  - Noted a `TMPDIR` workaround for Pis where `/tmp` is a small RAM-backed `tmpfs` too small for the build — point it at the SD card instead.

  ## Test plan

  - [x] Docs only, no code changes

  🤖 Generated with [Claude Code](https://claude.com/claude-code)